### PR TITLE
added expandenv flag

### DIFF
--- a/docs/config-tornjak-agent.md
+++ b/docs/config-tornjak-agent.md
@@ -77,9 +77,9 @@ The following flags are available for all tornjak-agent commands:
 
 | Command                | Action                             | Default | Required |
 |:-----------------------|:-----------------------------------|:--------| :--------|
-| `-spire-config`,`-c`   | Config file path for SPIRE server  |         | True     |
-| `-tornjak-config`,`-t` | Config file path for Tornjak agent |         | True     |
-| `expandEnv`            | If flag included, expand environment variables of Tornjak config | False | False   |
+| `-spire-config`,`-c`   | Config file path for SPIRE server  |         | true     |
+| `-tornjak-config`,`-t` | Config file path for Tornjak agent |         | true     |
+| `-expandEnv`           | If flag included, expand environment variables in Tornjak config | false   | false    |
 
 ### `tornjak-agent http`
 
@@ -90,9 +90,9 @@ Runs the tornjak http server.
 | `-listen-addr` | listening address for tornjak agent               | :10000  | false    |
 | `-cert`        | CA Cert path for TLS                              |         | false    |
 | `-key`         | Key path for TLS                                  |         | false    |
-| `mtls-ca`      | CA path for mTLS CA                               |         | false    |
-| `tls`          | Enable TLS for http server                        | false   | false    |
-| `mtls`         | enable mTLS for http server (overwrites tls flag) | false   | false    |
+| `-mtls-ca`     | CA path for mTLS CA                               |         | false    |
+| `-tls`         | Enable TLS for http server                        | false   | false    |
+| `-mtls`        | enable mTLS for http server (overwrites tls flag) | false   | false    |
 
 ## Further reading
 

--- a/docs/config-tornjak-agent.md
+++ b/docs/config-tornjak-agent.md
@@ -79,6 +79,7 @@ The following flags are available for all tornjak-agent commands:
 |:-----------------------|:-----------------------------------|:--------| :--------|
 | `-spire-config`,`-c`   | Config file path for SPIRE server  |         | True     |
 | `-tornjak-config`,`-t` | Config file path for Tornjak agent |         | True     |
+| `expandEnv`            | If flag included, expand environment variables of Tornjak config | False | False   |
 
 ### `tornjak-agent http`
 

--- a/run_backend.sh
+++ b/run_backend.sh
@@ -7,7 +7,7 @@ Usage: run_server [-c <file>] [-t <file>]
 
 -c | -config <file>: SPIRE Config File
 -t | -tornjak-config <file>: Tornjak Config File
--expandEnv | expand environment variables expressed in Tornjak Config File
+-expandEnv : if flag included, expand environment variables expressed in Tornjak Config File
 EOF
 	exit 1
 }

--- a/run_backend.sh
+++ b/run_backend.sh
@@ -7,7 +7,7 @@ Usage: run_server [-c <file>] [-t <file>]
 
 -c | -config <file>: SPIRE Config File
 -t | -tornjak-config <file>: Tornjak Config File
--expandEnv: expand environment variables expressed in config files
+-expandEnv | expand environment variables expressed in Tornjak Config File
 EOF
 	exit 1
 }

--- a/run_backend.sh
+++ b/run_backend.sh
@@ -7,6 +7,7 @@ Usage: run_server [-c <file>] [-t <file>]
 
 -c | -config <file>: SPIRE Config File
 -t | -tornjak-config <file>: Tornjak Config File
+-expandEnv: expand environment variables expressed in config files
 EOF
 	exit 1
 }
@@ -29,6 +30,10 @@ case $key in
 	shift
 	shift
 	;;
+	-expandEnv)
+	EXPAND_ENV="-expandEnv"
+	shift
+	;;
 	*)
 	echo "$key"
 	echo "$2"
@@ -46,13 +51,13 @@ if [[ "$SPIRE_CONFIG" == "" ]] ; then
 elif [[ "$TORNJAK_CONFIG" == "" ]] ; then
 	#echo "-t TORNJAK_CONFIG must be provided"
 	#exit 1
-	/opt/spire/tornjak-backend -c $SPIRE_CONFIG serverinfo &
-	/opt/spire/tornjak-backend -c $SPIRE_CONFIG http --tls --cert sample-keys/tls.pem --key sample-keys/key.pem  --listen-addr :20000 &
-	/opt/spire/tornjak-backend -c $SPIRE_CONFIG http --mtls --cert sample-keys/tls.pem --key sample-keys/key.pem  --mtls-ca sample-keys/rootCA.pem --listen-addr :30000 &
-	/opt/spire/tornjak-backend -c $SPIRE_CONFIG http
+	/opt/spire/tornjak-backend -c $SPIRE_CONFIG $EXPAND_ENV serverinfo &
+	/opt/spire/tornjak-backend -c $SPIRE_CONFIG $EXPAND_ENV http --tls --cert sample-keys/tls.pem --key sample-keys/key.pem  --listen-addr :20000 &
+	/opt/spire/tornjak-backend -c $SPIRE_CONFIG $EXPAND_ENV http --mtls --cert sample-keys/tls.pem --key sample-keys/key.pem  --mtls-ca sample-keys/rootCA.pem --listen-addr :30000 &
+	/opt/spire/tornjak-backend -c $SPIRE_CONFIG $EXPAND_ENV http
 else 
-	/opt/spire/tornjak-backend -c $SPIRE_CONFIG -t $TORNJAK_CONFIG serverinfo &
-	/opt/spire/tornjak-backend -c $SPIRE_CONFIG -t $TORNJAK_CONFIG http --tls --cert sample-keys/tls.pem --key sample-keys/key.pem  --listen-addr :20000 &
-	/opt/spire/tornjak-backend -c $SPIRE_CONFIG -t $TORNJAK_CONFIG http --mtls --cert sample-keys/tls.pem --key sample-keys/key.pem  --mtls-ca sample-keys/rootCA.pem --listen-addr :30000 &
-	/opt/spire/tornjak-backend -c $SPIRE_CONFIG -t $TORNJAK_CONFIG http
+	/opt/spire/tornjak-backend -c $SPIRE_CONFIG -t $TORNJAK_CONFIG $EXPAND_ENV serverinfo &
+	/opt/spire/tornjak-backend -c $SPIRE_CONFIG -t $TORNJAK_CONFIG $EXPAND_ENV http --tls --cert sample-keys/tls.pem --key sample-keys/key.pem  --listen-addr :20000 &
+	/opt/spire/tornjak-backend -c $SPIRE_CONFIG -t $TORNJAK_CONFIG $EXPAND_ENV http --mtls --cert sample-keys/tls.pem --key sample-keys/key.pem  --mtls-ca sample-keys/rootCA.pem --listen-addr :30000 &
+	/opt/spire/tornjak-backend -c $SPIRE_CONFIG -t $TORNJAK_CONFIG $EXPAND_ENV http
 fi

--- a/tornjak-backend/cmd/agent/agent.go
+++ b/tornjak-backend/cmd/agent/agent.go
@@ -130,7 +130,7 @@ func main() {
 
 func runTornjakCmd(cmd string, opt cliOptions) error {
 	// parse configs
-	config, err := run.ParseFile(opt.genericOptions.configFile, opt.genericOptions.expandEnv)
+	config, err := run.ParseFile(opt.genericOptions.configFile, false)
 	if err != nil {
 		// Hide internal error since it is specific to arguments of originating library
 		// i.e. asks to set -config which is a different flag in tornjak


### PR DESCRIPTION
Adding expandEnv flag to expand environment variables in Tornjak config

- [x] Concerns about expandEnv for the SPIRE config - the Tornjak container should not have access to the relevant environment variables
- [x] Need to update usage documentation

Signed-off-by: Maia Iyer <maia.raj.iyer@gmail.com>