### PR TITLE
Persist Tornjak DB info

### DIFF
--- a/docs/conf/agent/base.conf
+++ b/docs/conf/agent/base.conf
@@ -6,7 +6,7 @@ plugins {
   DataStore "sql" {
     plugin_data {
       drivername = "sqlite3"
-      filename = "./agentlocaldb"
+      filename = "/run/spire/data/tornjak.sqlite3"
     }
   }
 

--- a/docs/conf/agent/keycloak.conf
+++ b/docs/conf/agent/keycloak.conf
@@ -6,7 +6,7 @@ plugins {
   DataStore "sql" {
     plugin_data {
       drivername = "sqlite3"
-      filename = "./agentlocaldb"
+      filename = "/run/spire/data/tornjak.sqlite3"
     }
   }
 

--- a/docs/config-tornjak-agent.md
+++ b/docs/config-tornjak-agent.md
@@ -58,7 +58,7 @@ plugins {
     DataStore "sql" {
         plugin_data {
             database_type = "sqlite3"
-            connection_string = "./agentlocaldb"
+            connection_string = "/run/spire/data/tornjak.sqlite3"
         }
     }
 

--- a/docs/quickstart/README.md
+++ b/docs/quickstart/README.md
@@ -82,7 +82,7 @@ data:
       DataStore "sql" {
         plugin_data {
           drivername = "sqlite3"
-          filename = "./agentlocaldb"
+          filename = "/run/spire/data/tornjak.sqlite3"
         }
       }
 

--- a/docs/quickstart/tornjak-configmap.yaml
+++ b/docs/quickstart/tornjak-configmap.yaml
@@ -13,7 +13,7 @@ data:
       DataStore "sql" {
         plugin_data {
           drivername = "sqlite3"
-          filename = "./agentlocaldb"
+          filename = "/run/spire/data/tornjak.sqlite3"
         }
       }
 

--- a/tornjak-backend/api/agent/server.go
+++ b/tornjak-backend/api/agent/server.go
@@ -625,7 +625,7 @@ func (s *Server) ConfigureDefaults() (error) {
 	expBackoff := backoff.NewExponentialBackOff()
 	expBackoff.MaxElapsedTime = time.Second
 
-	s.Db, err = agentdb.NewLocalSqliteDB("sqlite3", "./localtornjakdb", expBackoff)
+	s.Db, err = agentdb.NewLocalSqliteDB("sqlite3", "./tornjak.sqlite3", expBackoff)
 	if err != nil {
 		return errors.Errorf("Cannot configure default datastore plugin: %v", err)
 	}


### PR DESCRIPTION
Tornjak DB has to be moved to the persistent storage, e.g. same place where the SPIRE DB is kept. 
Move the Tornjak DB to persistent storage and update the file name to be more descriptive. 
This PR resolves issue #137 