### PR TITLE
Reverting back to node:16

### DIFF
--- a/Dockerfile.frontend-container
+++ b/Dockerfile.frontend-container
@@ -1,5 +1,5 @@
 
-FROM node:19-alpine
+FROM node:16-alpine
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
- Due to node version 17+ openssl error reverting back to node16