### PR TITLE
Adding path module and a fallback - frontend

### DIFF
--- a/tornjak-frontend/package-lock.json
+++ b/tornjak-frontend/package-lock.json
@@ -81,6 +81,7 @@
         "jest-transform-stub": "^2.0.0",
         "moxios": "^0.4.0",
         "nodemon": "^2.0.13",
+        "path-browserify": "^1.0.1",
         "puppeteer": "^10.4.0",
         "react-test-renderer": "^17.0.2",
         "redux-mock-store": "^1.5.4"
@@ -16961,6 +16962,11 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
+    "node_modules/node-libs-browser/node_modules/path-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
+    },
     "node_modules/node-libs-browser/node_modules/punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -17767,9 +17773,10 @@
       }
     },
     "node_modules/path-browserify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
-      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true
     },
     "node_modules/path-dirname": {
       "version": "1.0.2",
@@ -40590,6 +40597,11 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         },
+        "path-browserify": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+          "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
+        },
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -41207,9 +41219,10 @@
       "integrity": "sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw=="
     },
     "path-browserify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
-      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true
     },
     "path-dirname": {
       "version": "1.0.2",

--- a/tornjak-frontend/package.json
+++ b/tornjak-frontend/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@babel/plugin-transform-runtime": "^7.15.0",
+    "@babel/preset-env": "^7.15.6",
     "@babel/runtime": "^7.15.4",
     "@carbon/charts": "^0.41.80",
     "@carbon/charts-react": "^0.41.80",
@@ -53,13 +55,11 @@
     "redux": "^4.1.1",
     "redux-devtools-extension": "^2.13.9",
     "redux-thunk": "^2.3.0",
+    "sass": "^1.60.0",
     "stringify-object": "^4.0.1",
     "url-join": "^4.0.1",
     "web-vitals": "^0.2.4",
-    "xlsx": "^0.18.5",
-    "sass": "^1.60.0",
-    "@babel/plugin-transform-runtime": "^7.15.0",
-    "@babel/preset-env": "^7.15.6"
+    "xlsx": "^0.18.5"
   },
   "scripts": {
     "start": "PORT=$PORT_FE react-scripts start --openssl-legacy-provider",
@@ -102,6 +102,7 @@
     "jest-transform-stub": "^2.0.0",
     "moxios": "^0.4.0",
     "nodemon": "^2.0.13",
+    "path-browserify": "^1.0.1",
     "puppeteer": "^10.4.0",
     "react-test-renderer": "^17.0.2",
     "redux-mock-store": "^1.5.4"

--- a/tornjak-frontend/webpack.config.js
+++ b/tornjak-frontend/webpack.config.js
@@ -1,0 +1,9 @@
+const path = require('path');
+
+module.exports = {
+  resolve: {
+    fallback: {
+      path: require.resolve('path-browserify')
+    }
+  }
+};


### PR DESCRIPTION
Solves: 
Module not found: Error: Can't resolve 'path' in '/home/runner/work/tornjak/tornjak/tornjak-frontend/node_modules/dotenv/lib' 478
BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default. 479
This is no longer the case. Verify if you need this module and configure a polyfill for it. 480
If you want to include a polyfill, you need to: 482
	- add a fallback 'resolve.fallback: { "path": require.resolve("path-browserify") }' 483
	- install 'path-browserify' 484
If you don't want to include a polyfill, you can use an empty module like this: 485
	resolve.fallback: { "path": false } 486
make: *** [Makefile:43: ui-manager] Error 1