### PR TITLE
Removing agent folder from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ tornjak-manager
 bin/
 ui/
 ui-agent/
-agent
 node_modules/
 ui-manager/
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ node_modules/
 ui-manager/
 .idea/
 Makefile
+


### PR DESCRIPTION
It is unclear why agent was added. It has the effect of ignoring all `tornjak-backend/*/agent` folders, and it's unclear what else is ignored. Small fix

Closes #167 