### PR TITLE
Fix 'access denied' error when running in restricted (read-only) env

### DIFF
--- a/Dockerfile.frontend-container
+++ b/Dockerfile.frontend-container
@@ -19,10 +19,6 @@ RUN npm install --location=global serve && \
 ENV PORT_FE=3000
 EXPOSE $PORT_FE
 
-# fix "access denied" error when running in restricted (read-only) env
-RUN ln -s /tmp/env.js build/env.js
-ENTRYPOINT npx react-inject-env set -n /tmp/env.js && serve -s build -p $PORT_FE
-
 # add a version link to the image description
 ARG version
 ARG github_sha
@@ -35,4 +31,7 @@ ENV GITHUB_SHA=$github_sha
 
 RUN npm install --omit=dev \
     npm prune --production
-ENTRYPOINT npx react-inject-env set && serve -s build -p $PORT_FE
+    
+# fix "access denied" error when running in restricted (read-only) env
+RUN ln -s /tmp/env.js build/env.js
+ENTRYPOINT npx react-inject-env set -n /tmp/env.js && serve -s build -p $PORT_FE

--- a/Dockerfile.frontend-container
+++ b/Dockerfile.frontend-container
@@ -19,7 +19,9 @@ RUN npm install --location=global serve && \
 ENV PORT_FE=3000
 EXPOSE $PORT_FE
 
-ENTRYPOINT npx react-inject-env set && serve -s build -p $PORT_FE
+# fix "access denied" error when running in restricted (read-only) env
+RUN ln -s /tmp/env.js build/env.js
+ENTRYPOINT npx react-inject-env set -n /tmp/env.js && serve -s build -p $PORT_FE
 
 # add a version link to the image description
 ARG version


### PR DESCRIPTION
When container image deployed in read-only environment (e.g. restricted namespace), write-access is required for outputting "env.js" file. Redirecting output of this file to "/tmp" directory