### PR TITLE
Removing symbolic link for enj.js [For testing purpose]

### DIFF
--- a/Dockerfile.frontend-container
+++ b/Dockerfile.frontend-container
@@ -20,8 +20,9 @@ ENV PORT_FE=3000
 EXPOSE $PORT_FE
 
 # fix "access denied" error when running in restricted (read-only) env
-RUN ln -s /tmp/env.js build/env.js
-ENTRYPOINT npx react-inject-env set -n env.js && serve -s build -p $PORT_FE
+# RUN ln -s /tmp/env.js build/env.js
+# ENTRYPOINT npx react-inject-env set -n env.js && serve -s build -p $PORT_FE
+ENTRYPOINT npx react-inject-env set && serve -s build -p $PORT_FE
 
 # add a version link to the image description
 ARG version


### PR DESCRIPTION
- Removing symbolic link for enj.js for environment variables dynamic injection to test git image, as local image works