### PR TITLE
Remove spire config requirement from backend #129

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -24,12 +24,12 @@ This is meant to be deployed where it can access a SPIRE server. To run, the con
 
 | Flag                   | Description                                                 | Default | Arguments | Required |
 |:-----------------------|:------------------------------------------------------------|:--------|:----------|:---------|
-| `--spire-config`       | Config file path for SPIRE server                           |         | `<path>`  | true     |
+| `--spire-config`       | Config file path for SPIRE server                           |         | `<path>`  | false    |
 | `--tornjak-config`     | Config file path for Tornjak (see our [configuration reference](./docs/config-tornjak-agent.md)) | | `<path>` | true |
 | `--expandEnv`          | If included, expand environment variables in Tornjak config | False   |           | false    |
 
 ```
-docker run -p 10000:10000 ghcr.io/spiffe/tornjak-backend:latest -c <SPIRE CONFIG PATH> -t <TORNJAK CONFIG PATH> -expandEnv
+docker run -p 10000:10000 ghcr.io/spiffe/tornjak-backend:latest --spire-config <SPIRE CONFIG PATH> --tornjak-config <TORNJAK CONFIG PATH> -expandEnv
 ```
 
 The above command creates a container listening at http://localhost:10000 for Tornjak API calls. Note that the config files must be accessible from INSIDE the container. Also note, this expands the container's environment variables in the Tornjak config map. 
@@ -73,7 +73,7 @@ This container may be used as an alternative to having a frontend and backend co
 An example command:
 
 ```
-docker run -p 10000:10000 -p 3000:8080 -e REACT_APP_API_SERVER_URI='http://localhost:10000' -e PORT_FE-8080 -e PORT_BE-10000 ghcr.io/spiffe/tornjak:latest -c <SPIRE CONFIG PATH> -t <TORNJAK CONFIG PATH>
+docker run -p 10000:10000 -p 3000:8080 -e REACT_APP_API_SERVER_URI='http://localhost:10000' -e PORT_FE-8080 -e PORT_BE-10000 ghcr.io/spiffe/tornjak:latest --spire-config <SPIRE CONFIG PATH> --tornjak-config <TORNJAK CONFIG PATH>
 ```
 
 The above command creates a UI available at `http://localhost:3000` forwarded from container port `8080`. It is listening to the Tornjak backend at `http://localhost:10000`, as given by the `REACT_APP_API_SERVER_URI` value. At the same time, the container is exposing port `10000` for the backend, which reads the SPIRE config and Tornjak config at `<SPIRE CONFIG PATH>` and `<TORNJAK CONFIG PATH>` respectively. 

--- a/docs/config-tornjak-server.md
+++ b/docs/config-tornjak-server.md
@@ -16,7 +16,7 @@ The following flags are available for all tornjak-agent commands:
 
 | Command                | Action                             | Default | Required |
 |:-----------------------|:-----------------------------------|:--------| :--------|
-| `--spire-config`       | Config file path for SPIRE server  |         | true     |
+| `--spire-config`       | Config file path for SPIRE server  |         | false    |
 | `--tornjak-config`     | Config file path for Tornjak agent |         | true     |
 | `--expandEnv`          | If flag included, expand environment variables in Tornjak config | false   | false    |
 

--- a/tornjak-backend/api/agent/api.go
+++ b/tornjak-backend/api/agent/api.go
@@ -209,6 +209,9 @@ type GetTornjakServerInfoRequest struct{}
 type GetTornjakServerInfoResponse TornjakSpireServerInfo
 
 func (s *Server) GetTornjakServerInfo(inp GetTornjakServerInfoRequest) (*GetTornjakServerInfoResponse, error) {
+	if s.SpireServerInfo.TrustDomain == "" {
+		return nil, errors.New("No SPIRE config provided to Tornjak")
+	}
 	return (*GetTornjakServerInfoResponse)(&s.SpireServerInfo), nil
 }
 

--- a/tornjak-backend/api/agent/server.go
+++ b/tornjak-backend/api/agent/server.go
@@ -461,8 +461,9 @@ func (s *Server) tornjakGetServerInfo(w http.ResponseWriter, r *http.Request) {
 
 	ret, err := s.GetTornjakServerInfo(input)
 	if err != nil {
-		// The only error currently is when serverinfo is empty
-		// This is not a serious error and should return 204 for no content
+		// The error occurs only when serverinfo is empty
+		// This indicates --spire-config not passed
+		// return 204 for no content
 		emsg := fmt.Sprintf("Error: %v", err.Error())
 		retError(w, emsg, http.StatusNoContent)
 		return

--- a/tornjak-backend/api/agent/server.go
+++ b/tornjak-backend/api/agent/server.go
@@ -461,8 +461,10 @@ func (s *Server) tornjakGetServerInfo(w http.ResponseWriter, r *http.Request) {
 
 	ret, err := s.GetTornjakServerInfo(input)
 	if err != nil {
+		// The only error currently is when serverinfo is empty
+		// This is not a serious error and should return 204 for no content
 		emsg := fmt.Sprintf("Error: %v", err.Error())
-		retError(w, emsg, http.StatusBadRequest)
+		retError(w, emsg, http.StatusNoContent)
 		return
 	}
 
@@ -540,7 +542,6 @@ func (s *Server) GetRouter() (*mux.Router) {
 	// SPIRE server healthcheck
 	rtr.HandleFunc("/api/debugserver", s.debugServer)
 	rtr.HandleFunc("/api/healthcheck", s.healthcheck)
-	rtr.HandleFunc("/api/debugserver", s.debugServer)
 
 	// Agents
 	rtr.HandleFunc("/api/agent/list", s.agentList)


### PR DESCRIPTION
Closes #129 

- Removes serverinfo requirement from backend, so `--spire-config` flag is now optional
- Depends on PR #261 for the frontend to properly handle the new kind of return value from the backend
