### PR TITLE
Align Node version with LTS used in Dockerfile.tornjak-container

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
           go-version: '1.20'
       - uses: actions/setup-node@v2
         with:
-          node-version: '15'
+          node-version: '18'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/Dockerfile.frontend-container
+++ b/Dockerfile.frontend-container
@@ -1,12 +1,12 @@
 ## Build stage
-FROM node:16-alpine3.14 AS build
+FROM node:18-alpine3.14 AS build
 WORKDIR /usr/src/app
 COPY tornjak-frontend .
 RUN npm install && \
     npm run build
 
 ## Runtime stage
-FROM node:16-alpine3.14 AS runtime
+FROM node:18-alpine3.14 AS runtime
 WORKDIR /usr/src/app
 COPY --from=build /usr/src/app/build ./build
 COPY --from=build /usr/src/app/.env.prod .


### PR DESCRIPTION
Node 18 is the current LTS. This version is also used in the bundled image. Therefore aligning the node version in the standalone frontend image to use 18 there as well.