### PR TITLE
Update the mTLS secret name

### DIFF
--- a/examples/tls_mtls/README.md
+++ b/examples/tls_mtls/README.md
@@ -112,7 +112,7 @@ tls.key
 For mTLS we will additionally need to deliver a user CA certificate to the Tornjak container. Currently it is found at `CA-user/rootCA.crt`. The process is the same. First we create the secret:
 
 ```
-kubectl create secret generic -n spire tornjak-user-certs \
+kubectl create secret generic -n spire tornjak-user-ca \
   --from-file=CA-user/rootCA.crt
 ```
 
@@ -134,7 +134,7 @@ volumes:
       secretName: tornjak-server-tls
   - name: user-cas
     secret: 
-      secretName: tornjak-user-certs
+      secretName: tornjak-user-ca
       items: 
         - key: rootCA.crt
           path: userCA.crt
@@ -282,7 +282,7 @@ curl --cacert CA-server/rootCA.crt https://<Tornjak_TLS_endpoint>
 
 In order to make a TLS call we need only a CA certificate that can validate the certificate/key pair given to Tornjak in step 1.  In our case, we can use the certificate within `CA-server`.  
 
-Additionally, we must have a certificate/key pair locally that was signed by the CA certificate given to the Tornjak server via `tornjak-user-certs` secret when configuring mTLS.  In our case, we can use the certificate/key pair `user.crt` and `user.key`: 
+Additionally, we must have a certificate/key pair locally that was signed by the CA certificate given to the Tornjak server via `tornjak-user-ca` secret when configuring mTLS.  In our case, we can use the certificate/key pair `user.crt` and `user.key`: 
 
 ```
 curl --cacert CA-server/rootCA.crt --key user.key --cert user.crt https://<Tornjak_mTLS_endpoint> 


### PR DESCRIPTION
Change the name of the secret from `tornjak-user-cert` to `tornjak-user-ca`  to comply with SPIRE helm charts project requirements 