### PR TITLE
Added x509/JWT svid field to frontend Create entry page #236

### DIFF
--- a/docs/quickstart/tornjak-configmap.yaml
+++ b/docs/quickstart/tornjak-configmap.yaml
@@ -13,7 +13,7 @@ data:
 
       # configure HTTP connection to Tornjak server
       http {
-        port = 10080 # opens at port 10080
+        port = 10000 # opens at port 10080
       }
 
     }

--- a/tornjak-frontend/src/components/entry-create-json.tsx
+++ b/tornjak-frontend/src/components/entry-create-json.tsx
@@ -52,7 +52,8 @@ type CreateEntryJsonState = {
     parentIdPath: string,
     parentId: string,
     selectorsList: string,
-    ttl: number,
+    jwt_svid_ttl: number,
+    x509_svid_ttl: number,
     expiresAt: number,
     federatesWith: string,
     dnsNames: string,
@@ -80,7 +81,8 @@ class CreateEntryJson extends Component<CreateEntryJsonProp, CreateEntryJsonStat
         this.handleChange = this.handleChange.bind(this);
         this.setSelectedEntriesIds = this.setSelectedEntriesIds.bind(this);
         this.onChangeSelectors = this.onChangeSelectors.bind(this);
-        this.onChangeTtl = this.onChangeTtl.bind(this);
+        this.onChangex509Ttl = this.onChangex509Ttl.bind(this);
+        this.onChangeJwtTtl = this.onChangeJwtTtl.bind(this);
         this.onChangeExpiresAt = this.onChangeExpiresAt.bind(this);
         this.onChangeFederatesWith = this.onChangeFederatesWith.bind(this);
         this.onChangeDnsNames = this.onChangeDnsNames.bind(this);
@@ -102,7 +104,8 @@ class CreateEntryJson extends Component<CreateEntryJsonProp, CreateEntryJsonStat
                 spiffe_id: { trust_domain: "", path: "" },
                 parent_id: { trust_domain: "", path: "" },
                 selectors: [],
-                ttl: 0,
+                jwt_svid_ttl: 0,
+                x509_svid_ttl: 0,
                 federates_with: [],
                 admin: false,
                 downstream: false,
@@ -121,7 +124,8 @@ class CreateEntryJson extends Component<CreateEntryJsonProp, CreateEntryJsonStat
             parentIdPath: "",
             parentId: "",
             selectorsList: "",
-            ttl: 0,
+            x509_svid_ttl: 0,
+            jwt_svid_ttl: 0,
             expiresAt: 0,
             federatesWith: "",
             dnsNames: "",
@@ -258,7 +262,8 @@ class CreateEntryJson extends Component<CreateEntryJsonProp, CreateEntryJsonStat
             parentIdTrustDomain: parentId_trustDomain,
             parentIdPath: parentId_path,
             selectorsList: selectorsWithNewline,
-            ttl: localNewEntry.ttl,
+            x509_svid_ttl: localNewEntry.x509_svid_ttl,
+            jwt_svid_ttl: localNewEntry.jwt_svid_ttl,
             expiresAt: localNewEntry.expires_at,
             federatesWith: federates_with,
             dnsNames: dns_names,
@@ -333,13 +338,16 @@ class CreateEntryJson extends Component<CreateEntryJsonProp, CreateEntryJsonStat
         entriesToUpload[selectedEntryId]["parent_id"]["trust_domain"] = this.state.parentIdTrustDomain;
         entriesToUpload[selectedEntryId]["parent_id"]["path"] = this.state.parentIdPath;
         entriesToUpload[selectedEntryId]["selectors"] = selectorEntries;
-        if (this.state.ttl !== undefined) {
-            entriesToUpload[selectedEntryId]["ttl"] = this.state.ttl;
+        if (this.state.jwt_svid_ttl !== undefined) {
+            entriesToUpload[selectedEntryId]["jwt_svid_ttl"] = this.state.jwt_svid_ttl;
         }
-        if (this.state.ttl !== undefined) {
-            entriesToUpload[selectedEntryId]["expires_at"] = this.state.expiresAt;
+        if (this.state.x509_svid_ttl !== undefined) {
+            entriesToUpload[selectedEntryId]["x509_svid_ttl"] = this.state.x509_svid_ttl;
         }
         if (this.state.expiresAt !== undefined) {
+            entriesToUpload[selectedEntryId]["expires_at"] = this.state.expiresAt;
+        }
+        if (federatedWithList !== undefined) {
             entriesToUpload[selectedEntryId]["federates_with"] = federatedWithList;
         }
         if (this.state.dnsNames.length !== 0) {
@@ -361,7 +369,8 @@ class CreateEntryJson extends Component<CreateEntryJsonProp, CreateEntryJsonStat
             parentId: "",
             spiffeId: "",
             selectorsList: "",
-            ttl: 0,
+            x509_svid_ttl: 0,
+            jwt_svid_ttl: 0,
             expiresAt: 0,
             federatesWith: "",
             dnsNames: "",
@@ -412,9 +421,16 @@ class CreateEntryJson extends Component<CreateEntryJsonProp, CreateEntryJsonStat
     }
 
     // TODO(mamy-CS): e - any for now will be explicitly typed
-    onChangeTtl(e: any): void {
+    onChangeJwtTtl(e: any): void {
         this.setState({
-            ttl: Number(e.target.value)
+            jwt_svid_ttl: Number(e.target.value)
+        });
+    }
+
+    // TODO(mamy-CS): e - any for now will be explicitly typed
+    onChangex509Ttl(e: any): void {
+        this.setState({
+            x509_svid_ttl: Number(e.target.value)
         });
     }
 
@@ -463,7 +479,8 @@ class CreateEntryJson extends Component<CreateEntryJsonProp, CreateEntryJsonStat
             parentId: "",
             spiffeId: "",
             selectorsList: "",
-            ttl: 0,
+            x509_svid_ttl: 0,
+            jwt_svid_ttl: 0,
             expiresAt: 0,
             federatesWith: "",
             dnsNames: "",
@@ -792,15 +809,28 @@ class CreateEntryJson extends Component<CreateEntryJsonProp, CreateEntryJsonStat
                                                 <legend className="bx--label">Advanced</legend>
                                                 <div className="ttl-input" data-test="ttl-input">
                                                     <NumberInput
-                                                        helperText="Ttl for identities issued for this entry (In seconds)"
+                                                        helperText="x509 SVID Ttl for identities issued for this entry (In seconds) Overrides JWT TTL if set"
                                                         id="ttl-input"
                                                         invalidText="Number is not valid"
-                                                        label="Time to Leave (Ttl)"
+                                                        label="x509 Time to Leave (Ttl)"
                                                         //max={100}
                                                         min={0}
                                                         step={1}
-                                                        value={this.state.ttl}
-                                                        onChange={this.onChangeTtl}
+                                                        value={this.state.x509_svid_ttl}
+                                                        onChange={this.onChangex509Ttl}
+                                                    />
+                                                </div>
+                                                <div className="ttl-input" data-test="ttl-input">
+                                                    <NumberInput
+                                                        helperText="JWT SVID ttl for identities issued for this entry (In seconds) "
+                                                        id="ttl-input"
+                                                        invalidText="Number is not valid"
+                                                        label="JWT Time to Leave (Ttl)"
+                                                        //max={100}
+                                                        min={0}
+                                                        step={1}
+                                                        value={this.state.jwt_svid_ttl}
+                                                        onChange={this.onChangeJwtTtl}
                                                     />
                                                 </div>
                                                 <div className="expiresAt-input" data-test="expiresAt-input">

--- a/tornjak-frontend/src/components/entry-create.tsx
+++ b/tornjak-frontend/src/components/entry-create.tsx
@@ -105,7 +105,8 @@ type CreateEntryState = {
   selectors: string,
   selectorsRecommendationList: string,
   adminFlag: boolean,
-  ttl: number,
+  jwt_svid_ttl: number,
+  x509_svid_ttl: number,
   expiresAt: number,
   dnsNames: string,
   federatesWith: string,
@@ -139,7 +140,8 @@ class CreateEntry extends Component<CreateEntryProp, CreateEntryState> {
     this.prepareParentIdAgentsList = this.prepareParentIdAgentsList.bind(this);
     this.prepareSelectorsList = this.prepareSelectorsList.bind(this);
     this.onChangeSelectorsRecommended = this.onChangeSelectorsRecommended.bind(this);
-    this.onChangeTtl = this.onChangeTtl.bind(this);
+    this.onChangeJwtTtl = this.onChangeJwtTtl.bind(this);
+    this.onChangex509Ttl = this.onChangex509Ttl.bind(this);
     this.onChangeExpiresAt = this.onChangeExpiresAt.bind(this);
     this.onChangeFederatesWith = this.onChangeFederatesWith.bind(this);
     this.onChangeDownStream = this.onChangeDownStream.bind(this);
@@ -161,7 +163,8 @@ class CreateEntry extends Component<CreateEntryProp, CreateEntryState> {
       selectors: "",
       selectorsRecommendationList: "",
       adminFlag: false,
-      ttl: 0,
+      x509_svid_ttl: 0,
+      jwt_svid_ttl: 0,
       expiresAt: 0,
       dnsNames: "",
       federatesWith: "",
@@ -363,9 +366,15 @@ class CreateEntry extends Component<CreateEntryProp, CreateEntryState> {
   }
 
   // TODO(mamy-CS): e - any for now will be explicitly typed on currently open entry create PR
-  onChangeTtl(e: any): void {
+  onChangex509Ttl(e: any): void {
     this.setState({
-      ttl: Number(e.target.value)
+      x509_svid_ttl: Number(e.target.value)
+    });
+  }
+
+  onChangeJwtTtl(e: any): void {
+    this.setState({
+      jwt_svid_ttl: Number(e.target.value)
     });
   }
 
@@ -640,7 +649,8 @@ class CreateEntry extends Component<CreateEntryProp, CreateEntryState> {
         },
         selectors: selectorEntries,
         admin: this.state.adminFlag,
-        ttl: this.state.ttl,
+        x509_svid_ttl: this.state.x509_svid_ttl,
+        jwt_svid_ttl: this.state.jwt_svid_ttl,
         expires_at: this.props.globalEntryExpiryTime,
         downstream: this.state.downstream,
         federates_with: federatedWithList,
@@ -864,19 +874,32 @@ class CreateEntry extends Component<CreateEntryProp, CreateEntryState> {
                 <div className="advanced">
                   <fieldset className="bx--fieldset">
                     <legend className="bx--label">Advanced</legend>
-                    <div className="ttl-input" data-test="ttl-input">
-                      <NumberInput
-                        helperText="Ttl for identities issued for this entry (In seconds)"
-                        id="ttl-input"
-                        invalidText="Number is not valid"
-                        label="Time to Leave (Ttl)"
-                        //max={100}
-                        min={0}
-                        step={1}
-                        value={0}
-                        onChange={this.onChangeTtl}
-                      />
-                    </div>
+                      <div className="ttl-input" data-test="ttl-input">
+                        <NumberInput
+                            helperText="x509 SVID Ttl for identities issued for this entry (In seconds) Overrides JWT TTL if set"
+                            id="ttl-input"
+                            invalidText="Number is not valid"
+                            label="x509 Time to Leave (Ttl)"
+                            //max={100}
+                            min={0}
+                            step={1}
+                            value={this.state.x509_svid_ttl}
+                            onChange={this.onChangex509Ttl}
+                        />
+                      </div>
+                      <div className="ttl-input" data-test="ttl-input">
+                        <NumberInput
+                            helperText="JWT SVID ttl for identities issued for this entry (In seconds) "
+                            id="ttl-input"
+                            invalidText="Number is not valid"
+                            label="JWT Time to Leave (Ttl)"
+                            //max={100}
+                            min={0}
+                            step={1}
+                            value={this.state.jwt_svid_ttl}
+                            onChange={this.onChangeJwtTtl}
+                        />
+                      </div>
                     <div className="expiresAt-input" data-test="expiresAt-input">
                       <EntryExpiryFeatures />
                     </div>

--- a/tornjak-frontend/src/components/types.ts
+++ b/tornjak-frontend/src/components/types.ts
@@ -61,7 +61,8 @@ export interface EntriesList {
   // node attestation. Otherwise, these selectors represent those produced by
   // workload attestation.
   selectors: Array<Selector>;
-  ttl: number; // The time to live for identities issued for this entry (in seconds).
+  jwt_svid_ttl: number; // time to live for JWT SVID in seconds
+  x509_svid_ttl: number; // time to live for x509-SVID in seconds
   federates_with: string[]; // The names of trust domains the identity described by this entry federates with
   // Whether or not the identity described by this entry is an administrative
   // workload. Administrative workloads are granted additional access to


### PR DESCRIPTION
Closes #236 

This PR removes generic ttl field in frontend in favor of x509 and JWT ttl fields to be compatible with SPIRE server versions 1.5+