### PR TITLE
Add UBI description

### DIFF
--- a/Dockerfile.backend-container
+++ b/Dockerfile.backend-container
@@ -11,7 +11,7 @@ COPY bin/tornjak-backend tornjak-backend
 # add a version link to the image description
 ARG version
 ARG github_sha
-LABEL org.opencontainers.image.description="Tornjak backend ($version) image: https://github.com/spiffe/tornjak/releases/tag/$version" \
+LABEL org.opencontainers.image.description="Tornjak backend ($version) Alpine image: https://github.com/spiffe/tornjak/releases/tag/$version" \
       org.opencontainers.image.source="https://github.com/spiffe/tornjak" \
       org.opencontainers.image.documentation="https://github.com/spiffe/tornjak/tree/main/docs"
 

--- a/Dockerfile.backend-container
+++ b/Dockerfile.backend-container
@@ -11,7 +11,7 @@ COPY bin/tornjak-backend tornjak-backend
 # add a version link to the image description
 ARG version
 ARG github_sha
-LABEL org.opencontainers.image.description="Tornjak backend ($version) Alpine image: https://github.com/spiffe/tornjak/releases/tag/$version" \
+LABEL org.opencontainers.image.description="Tornjak backend ($version) Alpine based image: https://github.com/spiffe/tornjak/releases/tag/$version" \
       org.opencontainers.image.source="https://github.com/spiffe/tornjak" \
       org.opencontainers.image.documentation="https://github.com/spiffe/tornjak/tree/main/docs"
 

--- a/Dockerfile.backend-container
+++ b/Dockerfile.backend-container
@@ -11,7 +11,7 @@ COPY bin/tornjak-backend tornjak-backend
 # add a version link to the image description
 ARG version
 ARG github_sha
-LABEL org.opencontainers.image.description="Tornjak backend ($version): https://github.com/spiffe/tornjak/releases/tag/$version" \
+LABEL org.opencontainers.image.description="Tornjak backend ($version) image: https://github.com/spiffe/tornjak/releases/tag/$version" \
       org.opencontainers.image.source="https://github.com/spiffe/tornjak" \
       org.opencontainers.image.documentation="https://github.com/spiffe/tornjak/tree/main/docs"
 

--- a/Dockerfile.backend-container.ubi
+++ b/Dockerfile.backend-container.ubi
@@ -11,7 +11,7 @@ COPY bin/tornjak-backend tornjak-backend
 # add a version link to the image description
 ARG version
 ARG github_sha
-LABEL org.opencontainers.image.description="Tornjak backend ($version) UBI image: https://github.com/spiffe/tornjak/releases/tag/$version" \
+LABEL org.opencontainers.image.description="Tornjak backend ($version) UBI based image: https://github.com/spiffe/tornjak/releases/tag/$version" \
       org.opencontainers.image.source="https://github.com/spiffe/tornjak" \
       org.opencontainers.image.documentation="https://github.com/spiffe/tornjak/tree/main/docs"
 # replace UBI labels

--- a/Dockerfile.backend-container.ubi
+++ b/Dockerfile.backend-container.ubi
@@ -11,7 +11,7 @@ COPY bin/tornjak-backend tornjak-backend
 # add a version link to the image description
 ARG version
 ARG github_sha
-LABEL org.opencontainers.image.description="Tornjak backend ($version): https://github.com/spiffe/tornjak/releases/tag/$version" \
+LABEL org.opencontainers.image.description="Tornjak backend ($version) UBI image: https://github.com/spiffe/tornjak/releases/tag/$version" \
       org.opencontainers.image.source="https://github.com/spiffe/tornjak" \
       org.opencontainers.image.documentation="https://github.com/spiffe/tornjak/tree/main/docs"
 # replace UBI labels

--- a/Dockerfile.frontend-container
+++ b/Dockerfile.frontend-container
@@ -26,7 +26,7 @@ ENTRYPOINT npx react-inject-env set -n tmp/env.js && serve -s build -p $PORT_FE
 # add a version link to the image description
 ARG version
 ARG github_sha
-LABEL org.opencontainers.image.description="Tornjak frontend ($version) image: https://github.com/spiffe/tornjak/releases/tag/$version" \
+LABEL org.opencontainers.image.description="Tornjak frontend ($version) Alpine image: https://github.com/spiffe/tornjak/releases/tag/$version" \
       org.opencontainers.image.source="https://github.com/spiffe/tornjak" \
       org.opencontainers.image.documentation="https://github.com/spiffe/tornjak/tree/main/docs"
 # additional labels

--- a/Dockerfile.frontend-container
+++ b/Dockerfile.frontend-container
@@ -26,7 +26,7 @@ ENTRYPOINT npx react-inject-env set -n tmp/env.js && serve -s build -p $PORT_FE
 # add a version link to the image description
 ARG version
 ARG github_sha
-LABEL org.opencontainers.image.description="Tornjak frontend ($version) Alpine image: https://github.com/spiffe/tornjak/releases/tag/$version" \
+LABEL org.opencontainers.image.description="Tornjak frontend ($version) Alpine based image: https://github.com/spiffe/tornjak/releases/tag/$version" \
       org.opencontainers.image.source="https://github.com/spiffe/tornjak" \
       org.opencontainers.image.documentation="https://github.com/spiffe/tornjak/tree/main/docs"
 # additional labels

--- a/Dockerfile.frontend-container
+++ b/Dockerfile.frontend-container
@@ -26,7 +26,7 @@ ENTRYPOINT npx react-inject-env set -n tmp/env.js && serve -s build -p $PORT_FE
 # add a version link to the image description
 ARG version
 ARG github_sha
-LABEL org.opencontainers.image.description="Tornjak frontend ($version): https://github.com/spiffe/tornjak/releases/tag/$version" \
+LABEL org.opencontainers.image.description="Tornjak frontend ($version) image: https://github.com/spiffe/tornjak/releases/tag/$version" \
       org.opencontainers.image.source="https://github.com/spiffe/tornjak" \
       org.opencontainers.image.documentation="https://github.com/spiffe/tornjak/tree/main/docs"
 # additional labels

--- a/Dockerfile.frontend-container.ubi
+++ b/Dockerfile.frontend-container.ubi
@@ -32,7 +32,7 @@ ENTRYPOINT npx react-inject-env set -n tmp/env.js && serve -s build -p $PORT_FE
 # add a version link to the image description
 ARG version
 ARG github_sha
-LABEL org.opencontainers.image.description="Tornjak frontend ($version) UBI Image: https://github.com/spiffe/tornjak/releases/tag/$version" \
+LABEL org.opencontainers.image.description="Tornjak frontend ($version) UBI based Image: https://github.com/spiffe/tornjak/releases/tag/$version" \
       org.opencontainers.image.source="https://github.com/spiffe/tornjak" \
       org.opencontainers.image.documentation="https://github.com/spiffe/tornjak/tree/main/docs"
 # replace UBI labels

--- a/Dockerfile.frontend-container.ubi
+++ b/Dockerfile.frontend-container.ubi
@@ -32,7 +32,7 @@ ENTRYPOINT npx react-inject-env set -n tmp/env.js && serve -s build -p $PORT_FE
 # add a version link to the image description
 ARG version
 ARG github_sha
-LABEL org.opencontainers.image.description="Tornjak frontend ($version): https://github.com/spiffe/tornjak/releases/tag/$version" \
+LABEL org.opencontainers.image.description="Tornjak frontend ($version) UBI Image: https://github.com/spiffe/tornjak/releases/tag/$version" \
       org.opencontainers.image.source="https://github.com/spiffe/tornjak" \
       org.opencontainers.image.documentation="https://github.com/spiffe/tornjak/tree/main/docs"
 # replace UBI labels


### PR DESCRIPTION
The Github package description does not specify whether an image was a UBI image or Alpine image. This adds the annotation. 