### PR TITLE
Fix frontend error on run 

### DIFF
--- a/frontend/Dockerfile.frontend-container
+++ b/frontend/Dockerfile.frontend-container
@@ -15,6 +15,7 @@ COPY --from=build /usr/src/app/.env.prod .
 RUN npm install -g npm@9.7.1 && \
     npm install --location=global serve && \
     npm install react-inject-env
+RUN mkdir build/tmp
     
 # Set dynamic port, defualt 3000
 ENV PORT_FE=3000

--- a/frontend/Dockerfile.frontend-container.ubi
+++ b/frontend/Dockerfile.frontend-container.ubi
@@ -15,6 +15,7 @@ COPY --from=build --chown=1001:0 /opt/app-root/src/.env.prod .
 RUN npm install -g npm@9.7.1 && \
     npm install --location=global serve && \
     npm install react-inject-env
+RUN mkdir build/tmp
 
 # Update permissions after build
 USER 0


### PR DESCRIPTION
Currently running the official image gives this error:

```
Status: Downloaded newer image for ghcr.io/spiffe/tornjak-frontend:v1.5.0
Setting the following environment variables:
{ REACT_APP_API_SERVER_URI: 'http://localhost:10000' }

Error: ENOENT: no such file or directory, open './build/tmp/env.js'
npm notice 
npm notice New major version of npm available! 9.7.1 -> 10.2.5
npm notice Changelog: <https://github.com/npm/cli/releases/tag/v10.2.5>
npm notice Run `npm install -g npm@10.2.5` to update!
npm notice 
```

Adding a line to mkdir for frontend for this not found file. 