### PR TITLE
Change CI Logic to Build on PR

### DIFF
--- a/.github/workflows/master-build.yaml
+++ b/.github/workflows/master-build.yaml
@@ -1,6 +1,6 @@
 name: Tornjak Artifact push
 on:
-  push: {}
+  pull_request: {}
   workflow_dispatch: {}
 jobs:
   alpine-build:
@@ -27,7 +27,7 @@ jobs:
 
       - name: Get branch name
         id: branch_name
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_BASE_REF})"
 
       - name: Run build
         uses: ./.github/actions/build


### PR DESCRIPTION
The current CI logic only executes a build on push. Dependabot fails when the action is triggered by a push event instead of a pull request event: [source](https://docs.github.com/en/code-security/code-scanning/troubleshooting-code-scanning/resource-not-accessible)