### PR TITLE
Push image on push event except dependabot

### DIFF
--- a/.github/workflows/master-build.yaml
+++ b/.github/workflows/master-build.yaml
@@ -1,6 +1,8 @@
 name: Tornjak Artifact push
 on:
-  pull_request: {}
+  push: 
+    branches-ignore:
+      - 'dependabot/**'
   workflow_dispatch: {}
 jobs:
   alpine-build:
@@ -27,7 +29,7 @@ jobs:
 
       - name: Get branch name
         id: branch_name
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_BASE_REF})"
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
 
       - name: Run build
         uses: ./.github/actions/build


### PR DESCRIPTION
Reverting previous change to build and push on pull request

Instead, only push on push event, excluding dependabot branches