### PR TITLE
Modify JWKS URL in config to Issuer URL for OIDC Discovery in Backend (#370)

### DIFF
--- a/api/agent/server.go
+++ b/api/agent/server.go
@@ -765,6 +765,11 @@ func NewAuth(authPlugin *ast.ObjectItem) (auth.Auth, error) {
 
 	switch key {
 	case "KeycloakAuth":
+		// check if data is defined
+		if data == nil {
+			return nil, errors.New("KeycloakAuth UserManagement plugin ('config > plugins > UserManagement KeycloakAuth > plugin_data') no populated")
+		}
+		fmt.Printf("KeycloakAuth Usermanagement Data: %+v\n", data)
 		// decode config to struct
 		var config pluginAuthKeycloak
 		if err := hcl.DecodeObject(&config, data); err != nil {
@@ -772,7 +777,7 @@ func NewAuth(authPlugin *ast.ObjectItem) (auth.Auth, error) {
 		}
 
 		// create verifier TODO make json an option?
-		verifier, err := auth.NewKeycloakVerifier(true, config.JwksURL, config.RedirectURL)
+		verifier, err := auth.NewKeycloakVerifier(true, config.IssuerURL)
 		if err != nil {
 			return nil, errors.Errorf("Couldn't configure Auth: %v", err)
 		}

--- a/api/agent/types.go
+++ b/api/agent/types.go
@@ -104,11 +104,10 @@ func (h HTTPSConfig) Parse() (*tls.Config, error) {
 
 /* Plugin types */
 type pluginDataStoreSQL struct {
-	Drivername string `json:"drivername"`
-	Filename   string `json:"filename"`
+	Drivername string `hcl:"drivername"`
+	Filename   string `hcl:"filename"`
 }
 
 type pluginAuthKeycloak struct {
-	JwksURL     string
-	RedirectURL string
+	IssuerURL string `hcl:"issuer"`
 }

--- a/docs/conf/agent/full.conf
+++ b/docs/conf/agent/full.conf
@@ -44,17 +44,12 @@ plugins {
   # Configure Keycloak as external Authentication server
   UserManagement "KeycloakAuth" {
     plugin_data {
-      # jwksURL - URL for JWKS verification
+      # issuer - Issuer URL for OIDC
       # here is a sample for Keycloak running locally on Minikube
-      jwksURL = "http://host.minikube.internal:8080/realms/tornjak/protocol/openid-connect/certs"
+      issuer = "http://host.docker.internal:8080/realms/tornjak"
       # for cloud deployment it would be something like:
-      # jwksURL = "http://<ingress_access>/realms/tornjak/protocol/openid-connect/certs"
+      # issuer = "http://<ingress_access>/realms/tornjak"
 
-      # redirectURL - URL for redirecting after successful authentication
-      # here is a sample for Keycloak running locally on minikube
-      redirectURL = "http://localhost:8080/realms/tornjak/protocol/openid-connect/auth?client_id=Tornjak-React-auth"
-      # for a cloud deployment it would look something like:
-      # redirectURL= "http://<ingress_access>/realms/tornjak/protocol/openid-connect/auth?client_id=Tornjak-React-auth"
     }
   }
 


### PR DESCRIPTION
Instead of passing JWKS URL to backend, we pass Issuer URL

closes #370 