### PR TITLE
Rename directory in Tornjak Backend container

### DIFF
--- a/Dockerfile.backend-container
+++ b/Dockerfile.backend-container
@@ -18,10 +18,10 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then CC=aarch64-alpine-linux-musl; fi && \
     go build --tags 'sqlite_json' -mod=vendor -ldflags '-s -w -linkmode external -extldflags "-static"' -o bin/tornjak-backend ./cmd/agent/main.go
 
 FROM alpine AS runtime
-RUN mkdir -p /opt/spire
+RUN mkdir -p /opt/tornjak
 
-WORKDIR /opt/spire
-ENTRYPOINT ["/opt/spire/run_backend.sh"]
+WORKDIR /opt/tornjak
+ENTRYPOINT ["/opt/tornjak/run_backend.sh"]
 
 # Add init
 COPY scripts/run_backend.sh run_backend.sh

--- a/Dockerfile.backend-container.ubi
+++ b/Dockerfile.backend-container.ubi
@@ -18,10 +18,10 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then CC=aarch64-alpine-linux-musl; fi && \
     go build --tags 'sqlite_json' -mod=vendor -ldflags '-s -w -linkmode external -extldflags "-static"' -o bin/tornjak-backend ./cmd/agent/main.go
 
 FROM registry.access.redhat.com/ubi8-micro:latest AS runtime
-RUN mkdir -p /opt/spire
+RUN mkdir -p /opt/tornjak
 
-WORKDIR /opt/spire
-ENTRYPOINT ["/opt/spire/run_backend.sh"]
+WORKDIR /opt/tornjak
+ENTRYPOINT ["/opt/tornjak/run_backend.sh"]
 
 # Add init
 COPY scripts/run_backend.sh run_backend.sh

--- a/examples/tls_mtls/README.md
+++ b/examples/tls_mtls/README.md
@@ -86,7 +86,7 @@ cat server-statefulset-tls.yaml
 volumeMounts:
 ...
   - name: tls-volume
-    mountPath: /opt/spire/server
+    mountPath: /opt/tornjak/server
 ...
 volumes:
 ...
@@ -123,9 +123,9 @@ Then we mount the secret to the Tornjak container via volume mount, as in the pr
 volumeMounts:
 ...
   - name: tls-volume
-    mountPath: /opt/spire/server
+    mountPath: /opt/tornjak/server
   - name: client-cas
-    mountPath: /opt/spire/clients
+    mountPath: /opt/tornjak/clients
 ...
 volumes:
 ...

--- a/examples/tls_mtls/server-statefulset-mtls.yaml
+++ b/examples/tls_mtls/server-statefulset-mtls.yaml
@@ -71,9 +71,9 @@ spec:
             - name: socket
               mountPath: /tmp/spire-server/private
             - name: tls-volume              # 👈 TLS SECRET VOLUME MOUNT
-              mountPath: /opt/spire/server  # 👈 TLS SECRET VOLUME MOUNT
+              mountPath: /opt/tornjak/server  # 👈 TLS SECRET VOLUME MOUNT
             - name: client-ca                 # 👈 mTLS CA SECRET VOLUME MOUNT
-              mountPath: /opt/spire/clients   # 👈 mTLS CA SECRET VOLUME MOUNT
+              mountPath: /opt/tornjak/clients   # 👈 mTLS CA SECRET VOLUME MOUNT
       volumes:
         - name: spire-config
           configMap:

--- a/examples/tls_mtls/server-statefulset-tls.yaml
+++ b/examples/tls_mtls/server-statefulset-tls.yaml
@@ -71,7 +71,7 @@ spec:
             - name: socket
               mountPath: /tmp/spire-server/private
             - name: secret-volume           # 👈 TLS SECRET VOLUME MOUNT
-              mountPath: /opt/spire/server  # 👈 TLS SECRET VOLUME MOUNT
+              mountPath: /opt/tornjak/server  # 👈 TLS SECRET VOLUME MOUNT
       volumes:
         - name: spire-config
           configMap:

--- a/scripts/run_backend.sh
+++ b/scripts/run_backend.sh
@@ -2,7 +2,7 @@
 echo "${@}"
 
 # run serverinfo to print SPIRE config if given and Tornjak config
-/opt/spire/tornjak-backend ${@} serverinfo
+/opt/tornjak/tornjak-backend ${@} serverinfo
 
 # run Tornjak server
-/opt/spire/tornjak-backend ${@} http
+/opt/tornjak/tornjak-backend ${@} http


### PR DESCRIPTION
### Changes proposed
This PR includes renaming the directory Tornjak from `/opt/spire` to `/opt/tornjak` mentioned in the opened issue #259 for:
- Dockerfiles backend;
- Shell script backend runner;
- All of its references in the `examples/` directory.