### PR TITLE
Added spire server unique identifier

### DIFF
--- a/frontend/src/components/navbar.tsx
+++ b/frontend/src/components/navbar.tsx
@@ -14,11 +14,13 @@ import {
   accessTokenUpdateFunc,
   UserRolesUpdateFunc,
 } from 'redux/actions';
+import { Tag } from 'carbon-components-react';
 import {
-  AccessToken
+  AccessToken,
+  ServerInfo
 } from './types';
 import HeaderToolBar from './navbar-header-toolbar';
-import {env} from '../env';
+import { env } from '../env';
 
 const Auth_Server_Uri = env.REACT_APP_AUTH_SERVER_URI;
 
@@ -39,6 +41,8 @@ type NavigationBarProp = {
   clickedDashboardTableFunc: (globalClickedDashboardTable: string) => void,
   // the clicked dashboard table
   globalClickedDashboardTable: string,
+  // the server trust domain and nodeAttestorPlugin as a ServerInfoType
+  globalServerInfo: ServerInfo,
 }
 
 type NavigationBarState = {}
@@ -133,6 +137,12 @@ class NavigationBar extends Component<NavigationBarProp, NavigationBarState> {
               <img src={tornjak_logo} height="50" width="160" alt="Tornjak" /></a>
           </span>
         </div>
+        {/* Temporarily using trust domain as server unique identifier */}
+        <div>
+          <Tag className="spire-server-unique-identifier" type="cyan">
+            Spire Server: {this.props.globalServerInfo.trustDomain}
+          </Tag>
+        </div>
       </div>
     );
   }
@@ -149,6 +159,7 @@ const mapStateToProps = (state: RootState) => ({
   globalIsAuthenticated: state.auth.globalIsAuthenticated,
   globalAccessToken: state.auth.globalAccessToken,
   globalUserRoles: state.auth.globalUserRoles,
+  globalServerInfo: state.servers.globalServerInfo,
 })
 
 export default connect(

--- a/frontend/src/components/navbar.tsx
+++ b/frontend/src/components/navbar.tsx
@@ -138,9 +138,9 @@ class NavigationBar extends Component<NavigationBarProp, NavigationBarState> {
           </span>
         </div>
         {/* Temporarily using trust domain as server unique identifier */}
-        <div>
-          <Tag className="spire-server-unique-identifier" type="cyan">
-            Spire Server: {this.props.globalServerInfo.trustDomain}
+        <div className="spire-server-unique-identifier">
+          <Tag type="cyan">
+            Trust Domain: {this.props.globalServerInfo.trustDomain}
           </Tag>
         </div>
       </div>

--- a/frontend/src/components/navbar.tsx
+++ b/frontend/src/components/navbar.tsx
@@ -8,16 +8,23 @@ import tornjak_logo from "res/tornjak_logo.png";
 import TornjakHelper from 'components/tornjak-helper';
 import KeycloakService from "auth/KeycloakAuth";
 import { RootState } from 'redux/reducers';
+import TornjakApi from './tornjak-api-helpers';
 import {
   clickedDashboardTableFunc,
   isAuthenticatedUpdateFunc,
   accessTokenUpdateFunc,
   UserRolesUpdateFunc,
+  serverInfoUpdateFunc,
+  tornjakServerInfoUpdateFunc,
+  spireDebugServerInfoUpdateFunc,
+  tornjakMessageFunc
 } from 'redux/actions';
 import { Tag } from 'carbon-components-react';
 import {
   AccessToken,
-  ServerInfo
+  ServerInfo,
+  DebugServerInfo,
+  TornjakServerInfo
 } from './types';
 import HeaderToolBar from './navbar-header-toolbar';
 import { env } from '../env';
@@ -43,15 +50,29 @@ type NavigationBarProp = {
   globalClickedDashboardTable: string,
   // the server trust domain and nodeAttestorPlugin as a ServerInfoType
   globalServerInfo: ServerInfo,
+  // tornjak server debug info of the selected server
+  globalDebugServerInfo: DebugServerInfo,
+  // tornjak server info of the selected server
+  globalTornjakServerInfo: TornjakServerInfo, 
+  // dispatches a payload for the server trust domain and nodeAttestorPlugin as a ServerInfoType and has a return type of void
+  serverInfoUpdateFunc: (globalServerInfo: ServerInfo) => void, 
+  // dispatches a payload for the tornjak server info of the selected server and has a return type of void
+  tornjakServerInfoUpdateFunc: (globalTornjakServerInfo: TornjakServerInfo) => void, 
+  // dispatches a payload for the debug server info of the selected server and has a return type of void
+  spireDebugServerInfoUpdateFunc: (globalDebugServerInfo: DebugServerInfo) => void,
+  // dispatches a payload for an Error Message/ Success Message of an executed function as a string and has a return type of void
+  tornjakMessageFunc: (globalErrorMessage: string) => void, 
 }
 
 type NavigationBarState = {}
 
 class NavigationBar extends Component<NavigationBarProp, NavigationBarState> {
   TornjakHelper: TornjakHelper;
+  TornjakApi: TornjakApi;
   constructor(props: NavigationBarProp) {
     super(props);
     this.TornjakHelper = new TornjakHelper({});
+    this.TornjakApi = new TornjakApi(props);
     this.state = {};
   }
 
@@ -68,6 +89,9 @@ class NavigationBar extends Component<NavigationBarProp, NavigationBarState> {
         }
       }
     }
+    this.TornjakApi.populateLocalTornjakServerInfo(this.props.tornjakServerInfoUpdateFunc, this.props.tornjakMessageFunc);
+    this.TornjakApi.populateLocalTornjakDebugServerInfo(this.props.spireDebugServerInfoUpdateFunc, this.props.tornjakMessageFunc);
+    this.TornjakApi.populateServerInfo(this.props.globalTornjakServerInfo, this.props.serverInfoUpdateFunc);
   }
 
   render() {
@@ -141,6 +165,7 @@ class NavigationBar extends Component<NavigationBarProp, NavigationBarState> {
         <div className="spire-server-unique-identifier">
           <Tag type="cyan">
             Trust Domain: {this.props.globalServerInfo.trustDomain}
+            <span style={{ fontWeight: 'bold' }}>{this.props.globalDebugServerInfo.svid_chain[0].id.path}</span>
           </Tag>
         </div>
       </div>
@@ -160,11 +185,22 @@ const mapStateToProps = (state: RootState) => ({
   globalAccessToken: state.auth.globalAccessToken,
   globalUserRoles: state.auth.globalUserRoles,
   globalServerInfo: state.servers.globalServerInfo,
+  globalDebugServerInfo: state.servers.globalDebugServerInfo,
+  globalTornjakServerInfo: state.servers.globalTornjakServerInfo,
 })
 
 export default connect(
   mapStateToProps,
-  { clickedDashboardTableFunc, isAuthenticatedUpdateFunc, accessTokenUpdateFunc, UserRolesUpdateFunc }
+  { 
+    clickedDashboardTableFunc, 
+    isAuthenticatedUpdateFunc, 
+    accessTokenUpdateFunc, 
+    UserRolesUpdateFunc,
+    serverInfoUpdateFunc,
+    tornjakServerInfoUpdateFunc,
+    spireDebugServerInfoUpdateFunc,
+    tornjakMessageFunc
+  }
 )(NavigationBar)
 
 export { NavigationBar }

--- a/frontend/src/components/navbar.tsx
+++ b/frontend/src/components/navbar.tsx
@@ -53,15 +53,15 @@ type NavigationBarProp = {
   // tornjak server debug info of the selected server
   globalDebugServerInfo: DebugServerInfo,
   // tornjak server info of the selected server
-  globalTornjakServerInfo: TornjakServerInfo, 
+  globalTornjakServerInfo: TornjakServerInfo,
   // dispatches a payload for the server trust domain and nodeAttestorPlugin as a ServerInfoType and has a return type of void
-  serverInfoUpdateFunc: (globalServerInfo: ServerInfo) => void, 
+  serverInfoUpdateFunc: (globalServerInfo: ServerInfo) => void,
   // dispatches a payload for the tornjak server info of the selected server and has a return type of void
-  tornjakServerInfoUpdateFunc: (globalTornjakServerInfo: TornjakServerInfo) => void, 
+  tornjakServerInfoUpdateFunc: (globalTornjakServerInfo: TornjakServerInfo) => void,
   // dispatches a payload for the debug server info of the selected server and has a return type of void
   spireDebugServerInfoUpdateFunc: (globalDebugServerInfo: DebugServerInfo) => void,
   // dispatches a payload for an Error Message/ Success Message of an executed function as a string and has a return type of void
-  tornjakMessageFunc: (globalErrorMessage: string) => void, 
+  tornjakMessageFunc: (globalErrorMessage: string) => void,
 }
 
 type NavigationBarState = {}
@@ -164,8 +164,9 @@ class NavigationBar extends Component<NavigationBarProp, NavigationBarState> {
         {/* Temporarily using trust domain as server unique identifier */}
         <div className="spire-server-unique-identifier">
           <Tag type="cyan">
-            Trust Domain: {this.props.globalServerInfo.trustDomain}
-            <span style={{ fontWeight: 'bold' }}>{this.props.globalDebugServerInfo.svid_chain[0].id.path}</span>
+            <span style={{ fontWeight: 'bold' }}>Server ID: </span>
+            {this.props.globalServerInfo.trustDomain}
+            <span style={{ textDecoration: 'underline', fontWeight: 'bold' }}>{this.props.globalDebugServerInfo.svid_chain[0].id.path}</span>
           </Tag>
         </div>
       </div>
@@ -191,10 +192,10 @@ const mapStateToProps = (state: RootState) => ({
 
 export default connect(
   mapStateToProps,
-  { 
-    clickedDashboardTableFunc, 
-    isAuthenticatedUpdateFunc, 
-    accessTokenUpdateFunc, 
+  {
+    clickedDashboardTableFunc,
+    isAuthenticatedUpdateFunc,
+    accessTokenUpdateFunc,
     UserRolesUpdateFunc,
     serverInfoUpdateFunc,
     tornjakServerInfoUpdateFunc,

--- a/frontend/src/components/navbar.tsx
+++ b/frontend/src/components/navbar.tsx
@@ -165,8 +165,8 @@ class NavigationBar extends Component<NavigationBarProp, NavigationBarState> {
         <div className="spire-server-unique-identifier">
           <Tag type="cyan">
             <span style={{ fontWeight: 'bold' }}>Server ID: </span>
-            {this.props.globalServerInfo.trustDomain}
-            <span style={{ textDecoration: 'underline', fontWeight: 'bold' }}>{this.props.globalDebugServerInfo.svid_chain[0].id.path}</span>
+            <span style={{ textDecoration: 'underline', fontWeight: 'bold' }}>{this.props.globalServerInfo.trustDomain}</span>
+            {this.props.globalDebugServerInfo.svid_chain[0].id.path}
           </Tag>
         </div>
       </div>

--- a/frontend/src/components/style.css
+++ b/frontend/src/components/style.css
@@ -426,3 +426,11 @@
   width: 180px;
   float: right;
 }
+.spire-server-unique-identifier {
+  margin-top: 20px;
+  margin-right: 20px;
+  z-index: 1000; /* High z-index to ensure it's on top */
+  position: relative;
+  display: inline;
+  float: right; /* Float to the right */
+}


### PR DESCRIPTION
- Using trust domain and path as spire server unique identifier for federation experiments
`Server ID: "trust-domain"/"path"`