### PR TITLE
Print Authorization Plugin Statements

### DIFF
--- a/api/agent/server.go
+++ b/api/agent/server.go
@@ -808,7 +808,7 @@ func (s *Server) GetRouter() http.Handler {
 	apiRtr.HandleFunc("/api/v1/spire/entries", s.entryList).Methods("GET")
 	apiRtr.HandleFunc("/api/v1/spire/entries", s.entryCreate).Methods("POST")
 	apiRtr.HandleFunc("/api/v1/spire/entries", s.entryDelete).Methods("DELETE")
-	apiRtr.HandleFunc("/api/v1/spire/bundle", s.bundleGet).Methods("GET")
+	apiRtr.HandleFunc("/api/v1/spire/bundles", s.bundleGet).Methods("GET")
 	apiRtr.HandleFunc("/api/v1/spire/federations/bundles", s.federatedBundleList).Methods("GET")
 	apiRtr.HandleFunc("/api/v1/spire/federations/bundles", s.federatedBundleCreate).Methods("POST")
 	apiRtr.HandleFunc("/api/v1/spire/federations/bundles", s.federatedBundleUpdate).Methods("PATCH")

--- a/api/agent/server.go
+++ b/api/agent/server.go
@@ -1073,7 +1073,10 @@ func NewAuthorizer(authorizerPlugin *ast.ObjectItem) (authorization.Authorizer, 
 			fmt.Printf("API name: %s, Allowed Roles: %s \n", api.Name, api.AllowedRoles)
 		}
 		for _, apiV1 := range config.APIv1RoleMappings{
-			fmt.Printf("API V1 method: %s, API V1 name: %s \n", apiV1.Method, apiV1.Name)
+			arr := strings.Split(apiV1.Name, " ")
+			apiV1.Method = arr[0]
+			apiV1.Path = arr[1]
+			fmt.Printf("API V1 method: %s, API V1 path: %s, API V1 allowed roles: %s \n", apiV1.Method, apiV1.Path, apiV1.AllowedRoles)
 		}
 
 		authorizer, err := authorization.NewRBACAuthorizer(config.Name, roleList, apiMapping)

--- a/api/agent/server.go
+++ b/api/agent/server.go
@@ -1070,6 +1070,10 @@ func NewAuthorizer(authorizerPlugin *ast.ObjectItem) (authorization.Authorizer, 
 		}
 		for _, api := range config.APIRoleMappings {
 			apiMapping[api.Name] = api.AllowedRoles
+			fmt.Printf("API name: %s, Allowed Roles: %s \n", api.Name, api.AllowedRoles)
+		}
+		for _, apiV1 := range config.APIv1RoleMappings{
+			fmt.Printf("API V1 method: %s, API V1 name: %s \n", apiV1.Method, apiV1.Name)
 		}
 
 		authorizer, err := authorization.NewRBACAuthorizer(config.Name, roleList, apiMapping)

--- a/api/agent/server.go
+++ b/api/agent/server.go
@@ -808,7 +808,7 @@ func (s *Server) GetRouter() http.Handler {
 	apiRtr.HandleFunc("/api/v1/spire/entries", s.entryList).Methods("GET")
 	apiRtr.HandleFunc("/api/v1/spire/entries", s.entryCreate).Methods("POST")
 	apiRtr.HandleFunc("/api/v1/spire/entries", s.entryDelete).Methods("DELETE")
-	apiRtr.HandleFunc("/api/v1/spire/bundles", s.bundleGet).Methods("GET")
+	apiRtr.HandleFunc("/api/v1/spire/bundle", s.bundleGet).Methods("GET")
 	apiRtr.HandleFunc("/api/v1/spire/federations/bundles", s.federatedBundleList).Methods("GET")
 	apiRtr.HandleFunc("/api/v1/spire/federations/bundles", s.federatedBundleCreate).Methods("POST")
 	apiRtr.HandleFunc("/api/v1/spire/federations/bundles", s.federatedBundleUpdate).Methods("PATCH")

--- a/api/agent/types.go
+++ b/api/agent/types.go
@@ -124,8 +124,9 @@ type APIRoleMapping struct {
 }
 
 type APIv1RoleMapping struct {
-	Method string `hcl:",key"`
 	Name string `hcl:",key"`
+	Method string `hcl:"-"`
+	Path string `hcl:"-"`
 	AllowedRoles []string `hcl:"allowed_roles"`
 }
 

--- a/api/agent/types.go
+++ b/api/agent/types.go
@@ -123,8 +123,15 @@ type APIRoleMapping struct {
 	AllowedRoles []string `hcl:"allowed_roles"`
 }
 
+type APIv1RoleMapping struct {
+	Method string `hcl:",key"`
+	Name string `hcl:",key"`
+	AllowedRoles []string `hcl:"allowed_roles"`
+}
+
 type pluginAuthorizerRBAC struct {
 	Name            string            `hcl:"name"`
 	RoleList        []*AuthRole       `hcl:"role,block"`
 	APIRoleMappings []*APIRoleMapping `hcl:"API,block"`
+	APIv1RoleMappings []*APIv1RoleMapping `hcl:"APIv1,block"`
 }

--- a/docs/conf/agent/full.conf
+++ b/docs/conf/agent/full.conf
@@ -89,7 +89,28 @@ plugins {
       API "/api/tornjak/clusters/create" { allowed_roles = ["admin"] }
       API "/api/tornjak/clusters/edit" { allowed_roles = ["admin"] }
       API "/api/tornjak/clusters/delete" { allowed_roles = ["admin"] }
-      APIv1 "GET" "/api/v1/spire/serverinfo" { allowed_roles = ["admin", "viewer"] }
+      APIv1 "GET /api/v1/spire/serverinfo" { allowed_roles = ["admin", "viewer"] }
+      APIv1 "GET /api/v1/spire/entries" { allowed_roles = ["admin", "viewer"] }
+      APIv1 "GET /api/v1/spire/agents"
+      APIv1 "POST /api/v1/spire/agents/ban"
+      APIv1 "DELETE /api/v1/spire/agents"
+      APIv1 "POST /api/v1/spire/agents/jointoken"
+      APIv1 "POST /api/v1/spire/entries"
+      APIv1 "POST /api/v1/spire/entries"
+      APIv1 "DELETE /api/v1/spire/entries"
+      APIv1 "GET /api/v1/spire/bundle"
+      APIv1 "GET /api/v1/spire/federations/bundles"
+      APIv1 "POST /api/v1/spire/federations/bundles"
+      APIv1 "PATCH /api/v1/spire/federations/bundles"
+      APIv1 "DELETE /api/v1/spire/federations/bundles"
+      APIv1 "GET /api/v1/tornjak/serverinfo"
+      APIv1 "POST /api/v1/tornjak/selectors"
+      APIv1 "GET /api/v1/tornjak/selectors"
+      APIv1 "GET /api/v1/tornjak/agents"
+      APIv1 "GET /api/v1/tornjak/clusters"
+      APIv1 "POST /api/v1/tornjak/clusters"
+      APIv1 "PATCH /api/v1/tornjak/clusters"
+      APIv1 "DELETE /api/v1/tornjak/clusters"
     }
   }
 

--- a/docs/conf/agent/full.conf
+++ b/docs/conf/agent/full.conf
@@ -41,22 +41,22 @@ plugins {
   ### BEGIN IAM PLUGIN CONFIGURATION ###
   # Note: if no UserManagement configuration included, authentication treated as noop
 
-  # This plugin will extract roles from `realm_access.roles` in the JWT and pass
-  # to the authorization layer as user roles.
-  # Authenticator "Keycloak" {
-  #   plugin_data {
-  #     # issuer - Issuer URL for OIDC
-  #     # here is a sample for Keycloak running locally on Minikube
-  #     issuer = "http://localhost:8080/realms/tornjak"
-  #     # for cloud deployment it would be something like:
-  #     # issuer = "http://<ingress_access>/realms/tornjak"
+  This plugin will extract roles from `realm_access.roles` in the JWT and pass
+  to the authorization layer as user roles.
+  Authenticator "Keycloak" {
+    plugin_data {
+      # issuer - Issuer URL for OIDC
+      # here is a sample for Keycloak running locally on Minikube
+      issuer = "http://localhost:8080/realms/tornjak"
+      # for cloud deployment it would be something like:
+      # issuer = "http://<ingress_access>/realms/tornjak"
 
-  #     # audience - expected value for aud claim in JWT
-  #     # if not included or set, there will be no audience check
-  #     # recommended to ensure JWT was meant for Tornjak Backend resource server
-  #     audience = "tornjak-backend"
-  #   }
-  # }
+      # audience - expected value for aud claim in JWT
+      # if not included or set, there will be no audience check
+      # recommended to ensure JWT was meant for Tornjak Backend resource server
+      audience = "tornjak-backend"
+    }
+  }
 
   # This policy requires admin role for all write calls, viewer role for all read calls
   # and authentication success for the "/" api
@@ -90,6 +90,7 @@ plugins {
       API "/api/tornjak/clusters/edit" { allowed_roles = ["admin"] }
       API "/api/tornjak/clusters/delete" { allowed_roles = ["admin"] }
       APIv1 "GET /api/v1/spire/serverinfo" { allowed_roles = ["admin", "viewer"] }
+      APIv1 "GET /api/v1/spire/healthcheck" { allowed_roles = ["admin", "viewer"] }
       APIv1 "GET /api/v1/spire/entries" { allowed_roles = ["admin", "viewer"] }
       APIv1 "GET /api/v1/spire/agents" { allowed_roles = ["admin", "viewer"] }
       APIv1 "POST /api/v1/spire/agents/ban" { allowed_roles = ["admin"] }
@@ -98,7 +99,7 @@ plugins {
       APIv1 "GET /api/v1/spire/entries" { allowed_roles = ["admin"] }
       APIv1 "POST /api/v1/spire/entries" { allowed_roles = ["admin"] }
       APIv1 "DELETE /api/v1/spire/entries" { allowed_roles = ["admin"] }
-      APIv1 "GET /api/v1/spire/bundles" { allowed_roles = ["admin", "viewer"] }
+      APIv1 "GET /api/v1/spire/bundle" { allowed_roles = ["admin", "viewer"] }
       APIv1 "GET /api/v1/spire/federations/bundles" { allowed_roles = ["admin", "viewer"] }
       APIv1 "POST /api/v1/spire/federations/bundles" { allowed_roles = ["admin"] }
       APIv1 "PATCH /api/v1/spire/federations/bundles" { allowed_roles = ["admin"] }

--- a/docs/conf/agent/full.conf
+++ b/docs/conf/agent/full.conf
@@ -41,13 +41,13 @@ plugins {
   ### BEGIN IAM PLUGIN CONFIGURATION ###
   # Note: if no UserManagement configuration included, authentication treated as noop
 
-  This plugin will extract roles from `realm_access.roles` in the JWT and pass
-  to the authorization layer as user roles.
+  # This plugin will extract roles from `realm_access.roles` in the JWT and pass
+  # to the authorization layer as user roles.
   Authenticator "Keycloak" {
     plugin_data {
       # issuer - Issuer URL for OIDC
       # here is a sample for Keycloak running locally on Minikube
-      issuer = "http://localhost:8080/realms/tornjak"
+      issuer = "http://host.docker.internal:8080/realms/tornjak"
       # for cloud deployment it would be something like:
       # issuer = "http://<ingress_access>/realms/tornjak"
 
@@ -96,7 +96,6 @@ plugins {
       APIv1 "POST /api/v1/spire/agents/ban" { allowed_roles = ["admin"] }
       APIv1 "DELETE /api/v1/spire/agents" { allowed_roles = ["admin"] }
       APIv1 "POST /api/v1/spire/agents/jointoken" { allowed_roles = ["admin"] }
-      APIv1 "GET /api/v1/spire/entries" { allowed_roles = ["admin"] }
       APIv1 "POST /api/v1/spire/entries" { allowed_roles = ["admin"] }
       APIv1 "DELETE /api/v1/spire/entries" { allowed_roles = ["admin"] }
       APIv1 "GET /api/v1/spire/bundle" { allowed_roles = ["admin", "viewer"] }

--- a/docs/conf/agent/full.conf
+++ b/docs/conf/agent/full.conf
@@ -32,7 +32,7 @@ plugins {
   DataStore "sql" {
     plugin_data {
       drivername = "sqlite3"
-      filename = "/run/spire/data/tornjak.sqlite3" # location of database
+      filename = "tornjak.sqlite3" # location of database
     }
   }
 
@@ -42,21 +42,21 @@ plugins {
   # Note: if no UserManagement configuration included, authentication treated as noop
 
   # This plugin will extract roles from `realm_access.roles` in the JWT and pass
-  # to the authorization layer as user roles. 
-  Authenticator "Keycloak" {
-    plugin_data {
-      # issuer - Issuer URL for OIDC
-      # here is a sample for Keycloak running locally on Minikube
-      issuer = "http://host.docker.internal:8080/realms/tornjak"
-      # for cloud deployment it would be something like:
-      # issuer = "http://<ingress_access>/realms/tornjak"
+  # to the authorization layer as user roles.
+  # Authenticator "Keycloak" {
+  #   plugin_data {
+  #     # issuer - Issuer URL for OIDC
+  #     # here is a sample for Keycloak running locally on Minikube
+  #     issuer = "http://localhost:8080/realms/tornjak"
+  #     # for cloud deployment it would be something like:
+  #     # issuer = "http://<ingress_access>/realms/tornjak"
 
-      # audience - expected value for aud claim in JWT
-      # if not included or set, there will be no audience check
-      # recommended to ensure JWT was meant for Tornjak Backend resource server
-      audience = "tornjak-backend"
-    }
-  }
+  #     # audience - expected value for aud claim in JWT
+  #     # if not included or set, there will be no audience check
+  #     # recommended to ensure JWT was meant for Tornjak Backend resource server
+  #     audience = "tornjak-backend"
+  #   }
+  # }
 
   # This policy requires admin role for all write calls, viewer role for all read calls
   # and authentication success for the "/" api
@@ -71,7 +71,7 @@ plugins {
       # home tornjak backend api allowed with any successful authentication
       API "/" { allowed_roles = [""] }
       # allowed with successful authentication and either admin or viewer role
-      API "/api/healthcheck" { allowed_roles = ["admin", "viewer"] } 
+      API "/api/healthcheck" { allowed_roles = ["admin", "viewer"] }
       API "/api/debugserver" { allowed_roles = ["admin", "viewer"] }
       API "/api/agent/list" { allowed_roles = ["admin", "viewer"] }
       API "/api/entry/list" { allowed_roles = ["admin", "viewer"] }
@@ -89,6 +89,7 @@ plugins {
       API "/api/tornjak/clusters/create" { allowed_roles = ["admin"] }
       API "/api/tornjak/clusters/edit" { allowed_roles = ["admin"] }
       API "/api/tornjak/clusters/delete" { allowed_roles = ["admin"] }
+      APIv1 "GET" "/api/v1/spire/serverinfo" { allowed_roles = ["admin", "viewer"] }
     }
   }
 

--- a/docs/conf/agent/full.conf
+++ b/docs/conf/agent/full.conf
@@ -91,26 +91,26 @@ plugins {
       API "/api/tornjak/clusters/delete" { allowed_roles = ["admin"] }
       APIv1 "GET /api/v1/spire/serverinfo" { allowed_roles = ["admin", "viewer"] }
       APIv1 "GET /api/v1/spire/entries" { allowed_roles = ["admin", "viewer"] }
-      APIv1 "GET /api/v1/spire/agents"
-      APIv1 "POST /api/v1/spire/agents/ban"
-      APIv1 "DELETE /api/v1/spire/agents"
-      APIv1 "POST /api/v1/spire/agents/jointoken"
-      APIv1 "POST /api/v1/spire/entries"
-      APIv1 "POST /api/v1/spire/entries"
-      APIv1 "DELETE /api/v1/spire/entries"
-      APIv1 "GET /api/v1/spire/bundle"
-      APIv1 "GET /api/v1/spire/federations/bundles"
-      APIv1 "POST /api/v1/spire/federations/bundles"
-      APIv1 "PATCH /api/v1/spire/federations/bundles"
-      APIv1 "DELETE /api/v1/spire/federations/bundles"
-      APIv1 "GET /api/v1/tornjak/serverinfo"
-      APIv1 "POST /api/v1/tornjak/selectors"
-      APIv1 "GET /api/v1/tornjak/selectors"
-      APIv1 "GET /api/v1/tornjak/agents"
-      APIv1 "GET /api/v1/tornjak/clusters"
-      APIv1 "POST /api/v1/tornjak/clusters"
-      APIv1 "PATCH /api/v1/tornjak/clusters"
-      APIv1 "DELETE /api/v1/tornjak/clusters"
+      APIv1 "GET /api/v1/spire/agents" { allowed_roles = ["admin", "viewer"] }
+      APIv1 "POST /api/v1/spire/agents/ban" { allowed_roles = ["admin"] }
+      APIv1 "DELETE /api/v1/spire/agents" { allowed_roles = ["admin"] }
+      APIv1 "POST /api/v1/spire/agents/jointoken" { allowed_roles = ["admin"] }
+      APIv1 "GET /api/v1/spire/entries" { allowed_roles = ["admin"] }
+      APIv1 "POST /api/v1/spire/entries" { allowed_roles = ["admin"] }
+      APIv1 "DELETE /api/v1/spire/entries" { allowed_roles = ["admin"] }
+      APIv1 "GET /api/v1/spire/bundles" { allowed_roles = ["admin", "viewer"] }
+      APIv1 "GET /api/v1/spire/federations/bundles" { allowed_roles = ["admin", "viewer"] }
+      APIv1 "POST /api/v1/spire/federations/bundles" { allowed_roles = ["admin"] }
+      APIv1 "PATCH /api/v1/spire/federations/bundles" { allowed_roles = ["admin"] }
+      APIv1 "DELETE /api/v1/spire/federations/bundles" { allowed_roles = ["admin"] }
+      APIv1 "GET /api/v1/tornjak/serverinfo" { allowed_roles = ["admin", "viewer"] }
+      APIv1 "POST /api/v1/tornjak/selectors" { allowed_roles = ["admin"] }
+      APIv1 "GET /api/v1/tornjak/selectors" { allowed_roles = ["admin", "viewer"] }
+      APIv1 "GET /api/v1/tornjak/agents" { allowed_roles = ["admin", "viewer"] }
+      APIv1 "GET /api/v1/tornjak/clusters" { allowed_roles = ["admin", "viewer"] }
+      APIv1 "POST /api/v1/tornjak/clusters" { allowed_roles = ["admin"] }
+      APIv1 "PATCH /api/v1/tornjak/clusters" { allowed_roles = ["admin"] }
+      APIv1 "DELETE /api/v1/tornjak/clusters" { allowed_roles = ["admin"] }
     }
   }
 


### PR DESCRIPTION
Changes in the code:
- In docs/conf/agent/full.conf line 92, added new API with method: APIv1 "GET" "/api/v1/spire/serverinfo" { allowed_roles = ["admin", "viewer"] }
- In api/agent/types.go line 126-130 and 136 added structure APIv1RoleMapping.
- In api/agent/server.go line 1073 and 1076 added print statements to compare outputs of both old and the new API.

Outputs:
- For the old API, we got something normal like API name: /api/healthcheck, Allowed Roles: [admin viewer]
- For the new API, we got: API V1 method: GET, API V1 name: GET.

Evaluation:
As of our current progress, looks like our current structure for our new API does not get desired printed output. Maybe 2 keys with string type does not correctly mapped to list AllowedRoles. We may consider a different data structure for the new API.