### PR TITLE
Fix documentation links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ The backend may also be run locally as well.
 go run tornjak-backend/cmd/agent/agent.go
 ```
 
-Note, the above command will print out usage documentation for the server. Please see our documentation for the backend [here](./docs/config-tornjak-agent.md) for more information.  Additionally, full functionality of the server requires a SPIRE server to be running.
+Note, the above command will print out usage documentation for the server. Please see our documentation for the backend [here](./docs/config-tornjak-server.md) for more information.  Additionally, full functionality of the server requires a SPIRE server to be running.
 
 ### Running the Tornjak Manager
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -26,7 +26,7 @@ The backend is designed to be deployed where it can access a SPIRE server. To ru
 | Flag                   | Description                                                 | Default | Arguments | Required |
 |:-----------------------|:------------------------------------------------------------|:--------|:----------|:---------|
 | `--spire-config`       | Config file path for SPIRE server                           |         | `<path>`  | false    |
-| `--tornjak-config`     | Config file path for Tornjak (see our [configuration reference](./docs/config-tornjak-agent.md)) | | `<path>` | true |
+| `--tornjak-config`     | Config file path for Tornjak (see our [configuration reference](./docs/config-tornjak-server.md)) | | `<path>` | true |
 | `--expandEnv`          | If included, expand environment variables in Tornjak config | False   |           | false    |
 
 ```
@@ -35,7 +35,7 @@ docker run -p 10000:10000 ghcr.io/spiffe/tornjak-backend:latest --spire-config <
 
 The above command creates a container listening at http://localhost:10000 for Tornjak API calls. Note that the config files must be accessible from INSIDE the container. Also note, this expands the container's environment variables in the Tornjak config map. 
 
-For more instructions on Tornjak config formatting, please see our [configuration reference](./docs/config-tornjak-agent.md).
+For more instructions on Tornjak config formatting, please see our [configuration reference](./docs/config-tornjak-server.md).
 
 ## Tornjak Manager
 


### PR DESCRIPTION
`docs/config-tornjak-agent.md` was renamed to `docs/config-tornjak-server.md` in https://github.com/spiffe/tornjak/pull/176/commits/4454586c73fd582f0fe47e6b2ee061cda86666c6. Therefore fix the two broken links in `CONTRIBUTING.md` and `USAGE.md`

Closes https://github.com/spiffe/tornjak/issues/660

