### PR TITLE
Generalize Keycloak role extraction to a configurable claim path

### DIFF
--- a/api/agent/config.go
+++ b/api/agent/config.go
@@ -141,7 +141,7 @@ func NewAuthenticator(authenticatorPlugin *ast.ObjectItem) (authenticator.Authen
 		}
 
 		// create authenticator TODO make json an option?
-		authenticator, err := authenticator.NewKeycloakAuthenticator(true, config.IssuerURL, config.Audience)
+		authenticator, err := authenticator.NewKeycloakAuthenticator(true, config.IssuerURL, config.Audience, config.RoleClaim)
 		if err != nil {
 			return nil, errors.Errorf("Couldn't configure Authenticator: %v", err)
 		}

--- a/api/agent/types.go
+++ b/api/agent/types.go
@@ -115,6 +115,7 @@ type pluginControllerManager struct {
 type pluginAuthenticatorKeycloak struct {
 	IssuerURL string `hcl:"issuer"`
 	Audience  string `hcl:"audience"`
+	RoleClaim string `hcl:"roleclaim"`
 }
 
 type AuthRole struct {

--- a/docs/conf/agent/full.conf
+++ b/docs/conf/agent/full.conf
@@ -51,8 +51,9 @@ plugins {
   ### BEGIN IAM PLUGIN CONFIGURATION ###
   # Note: if no UserManagement configuration included, authentication treated as noop
 
-  # This plugin will extract roles from `realm_access.roles` in the JWT and pass
-  # to the authorization layer as user roles. 
+  # This plugin will extract roles from `realm_access.roles` in the JWT by
+  # default (or from `roleclaim` below, if set) and pass them to the
+  # authorization layer as user roles.
   Authenticator "Keycloak" {
     plugin_data {
       # issuer - Issuer URL for OIDC
@@ -65,6 +66,11 @@ plugins {
       # if not included or set, there will be no audience check
       # recommended to ensure JWT was meant for Tornjak Backend resource server
       audience = "tornjak-backend"
+
+      # roleclaim - dot-separated path to the roles list in the JWT
+      # defaults to "realm_access.roles" if not set
+      # e.g. for Keycloak client roles instead of realm roles:
+      # roleclaim = "resource_access.tornjak-backend.roles"
     }
   }
 

--- a/docs/plugins/plugin_server_authentication_keycloak.md
+++ b/docs/plugins/plugin_server_authentication_keycloak.md
@@ -10,6 +10,7 @@ The configuration has the following key-value pairs:
 | ----------- | ----------------------------------------------------------------------- | ------------------- |
 | issuer      | Issuer URL for OIDC Discovery with external IAM System                  | True                |
 | audience    | Expected audience value in received JWT tokens                          | False (Recommended) |
+| roleclaim   | Dot-separated path to the roles list in the JWT (see below)             | False (default `realm_access.roles`) |
 
 A sample configuration file for syntactic referense is below:
 
@@ -18,6 +19,7 @@ A sample configuration file for syntactic referense is below:
         plugin_data {
             issuer = "http://host.docker.internal:8080/realms/tornjak"
             audience = "tornjak-backend"
+            roleclaim = "resource_access.tornjak-backend.roles"
         }
     }
 ```
@@ -27,6 +29,12 @@ It is highly recommended `audience` is populated to ensure only tokens meant for
 
 ## User Info extracted
 
-This plugin assumes roles are available in `realm_access.roles` in the JWT and passes this list as user.roles.
+By default, this plugin assumes roles are available in `realm_access.roles` in the JWT (Keycloak's default
+location for realm roles) and passes this list as user.roles.
+
+If your roles live elsewhere in the token - for example under `resource_access.<clientId>.roles`, which is
+where Keycloak places client-scoped roles - set `roleclaim` to a dot-separated path to that claim. The final
+segment must resolve to a list of strings; anything else (a missing claim, or a claim that isn't a string list)
+results in no roles being extracted for that request.
 
 These mapped values are passed to the authorization layer.

--- a/pkg/agent/authentication/authenticator/keycloak.go
+++ b/pkg/agent/authentication/authenticator/keycloak.go
@@ -16,19 +16,15 @@ import (
 	"github.com/spiffe/tornjak/pkg/agent/authentication/user"
 )
 
-type RealmAccessSubclaim struct {
-	Roles []string `json:"roles"`
-}
-
-type KeycloakClaim struct {
-	RealmAccess RealmAccessSubclaim `json:"realm_access"`
-	jwt.RegisteredClaims
-}
+// defaultRoleClaim is the claim path used when no roleclaim is configured,
+// preserving the pre-existing hardcoded behavior.
+const defaultRoleClaim = "realm_access.roles"
 
 type KeycloakAuthenticator struct {
-	jwks     *keyfunc.JWKS
-	jwksURL  string
-	audience string
+	jwks      *keyfunc.JWKS
+	jwksURL   string
+	audience  string
+	roleClaim string
 }
 
 func getJWKeyFunc(httpjwks bool, jwksInfo string) (*keyfunc.JWKS, error) {
@@ -59,7 +55,7 @@ func getJWKeyFunc(httpjwks bool, jwksInfo string) (*keyfunc.JWKS, error) {
 // newKeycloakAuthenticator (https bool, jwks string, redirect string)
 //
 //	get keyfunc based on https
-func NewKeycloakAuthenticator(httpjwks bool, issuerURL string, audience string) (*KeycloakAuthenticator, error) {
+func NewKeycloakAuthenticator(httpjwks bool, issuerURL string, audience string, roleClaim string) (*KeycloakAuthenticator, error) {
 	// perform OIDC discovery
 	oidcClient, err := discovery.NewClient(context.Background(), issuerURL)
 	if err != nil {
@@ -73,11 +69,57 @@ func NewKeycloakAuthenticator(httpjwks bool, issuerURL string, audience string) 
 	if err != nil {
 		return nil, err
 	}
+
 	return &KeycloakAuthenticator{
-		jwks:     jwks,
-		audience: audience,
-		jwksURL:  jwksURL,
+		jwks:      jwks,
+		audience:  audience,
+		jwksURL:   jwksURL,
+		roleClaim: resolveRoleClaim(roleClaim),
 	}, nil
+}
+
+// resolveRoleClaim falls back to defaultRoleClaim when no roleclaim is
+// configured, so existing deployments keep working unmodified.
+func resolveRoleClaim(configured string) string {
+	if configured == "" {
+		return defaultRoleClaim
+	}
+	return configured
+}
+
+// extractRoles walks a dot-separated claim path (e.g. "realm_access.roles" or
+// "resource_access.tornjak-backend.roles") through a parsed JWT claim set and
+// returns the role list found there. Returns nil if the path doesn't resolve
+// to a list of strings (missing claim, wrong shape, etc.).
+func extractRoles(claims jwt.MapClaims, path string) []string {
+	fields := strings.Split(path, ".")
+	current := map[string]interface{}(claims)
+
+	for i, field := range fields {
+		value, ok := current[field]
+		if !ok {
+			return nil
+		}
+		if i == len(fields)-1 {
+			list, ok := value.([]interface{})
+			if !ok {
+				return nil
+			}
+			roles := make([]string, 0, len(list))
+			for _, item := range list {
+				if str, ok := item.(string); ok {
+					roles = append(roles, str)
+				}
+			}
+			return roles
+		}
+		next, ok := value.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+		current = next
+	}
+	return nil
 }
 
 func getToken(r *http.Request, redirectURL string) (string, error) {
@@ -110,9 +152,8 @@ func (a *KeycloakAuthenticator) AuthenticateRequest(r *http.Request) *user.UserI
 	}
 
 	// parse token
-	claims := &KeycloakClaim{}
 	parserOptions := jwt.WithAudience(a.audience)
-	jwt_token, err := jwt.ParseWithClaims(token, claims, a.jwks.Keyfunc, parserOptions)
+	jwt_token, err := jwt.Parse(token, a.jwks.Keyfunc, parserOptions)
 	if err != nil {
 		return wrapAuthenticationError(errors.Errorf("Error parsing token :%s", err.Error()))
 	}
@@ -122,7 +163,12 @@ func (a *KeycloakAuthenticator) AuthenticateRequest(r *http.Request) *user.UserI
 		return wrapAuthenticationError(errors.New("Token invalid"))
 	}
 
+	claims, ok := jwt_token.Claims.(jwt.MapClaims)
+	if !ok {
+		return wrapAuthenticationError(errors.New("Could not parse token claims"))
+	}
+
 	return &user.UserInfo{
-		Roles: claims.RealmAccess.Roles,
+		Roles: extractRoles(claims, a.roleClaim),
 	}
 }

--- a/pkg/agent/authentication/authenticator/keycloak_test.go
+++ b/pkg/agent/authentication/authenticator/keycloak_test.go
@@ -1,0 +1,102 @@
+package authenticator
+
+import (
+	"reflect"
+	"testing"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+)
+
+// sampleClaims mirrors the shape of a real Keycloak access token: realm
+// roles under realm_access.roles, and client roles under
+// resource_access.<clientId>.roles.
+func sampleClaims() jwt.MapClaims {
+	return jwt.MapClaims{
+		"preferred_username": "admin",
+		"realm_access": map[string]interface{}{
+			"roles": []interface{}{"tornjak-admin-realm-role", "offline_access"},
+		},
+		"resource_access": map[string]interface{}{
+			"account": map[string]interface{}{
+				"roles": []interface{}{"manage-account", "view-profile"},
+			},
+		},
+	}
+}
+
+// TestExtractRoles_DefaultClaim is the control case: the default claim path
+// (realm_access.roles) must keep extracting roles exactly as the old
+// hardcoded implementation did.
+func TestExtractRoles_DefaultClaim(t *testing.T) {
+	roles := extractRoles(sampleClaims(), defaultRoleClaim)
+	expected := []string{"tornjak-admin-realm-role", "offline_access"}
+	if !reflect.DeepEqual(roles, expected) {
+		t.Fatalf("ERROR: expected %v, got %v", expected, roles)
+	}
+}
+
+// TestExtractRoles_ArbitraryClaim covers the actual feature request: an
+// arbitrary, nested claim path should now be readable, not just
+// realm_access.roles.
+func TestExtractRoles_ArbitraryClaim(t *testing.T) {
+	roles := extractRoles(sampleClaims(), "resource_access.account.roles")
+	expected := []string{"manage-account", "view-profile"}
+	if !reflect.DeepEqual(roles, expected) {
+		t.Fatalf("ERROR: expected %v, got %v", expected, roles)
+	}
+}
+
+// TestExtractRoles_SingleLevelClaim covers a flat (non-nested) claim path.
+func TestExtractRoles_SingleLevelClaim(t *testing.T) {
+	claims := jwt.MapClaims{
+		"roles": []interface{}{"viewer"},
+	}
+	roles := extractRoles(claims, "roles")
+	expected := []string{"viewer"}
+	if !reflect.DeepEqual(roles, expected) {
+		t.Fatalf("ERROR: expected %v, got %v", expected, roles)
+	}
+}
+
+// TestExtractRoles_MissingClaim ensures an unconfigured/missing path fails
+// closed (no roles) instead of panicking.
+func TestExtractRoles_MissingClaim(t *testing.T) {
+	roles := extractRoles(sampleClaims(), "resource_access.nonexistent-client.roles")
+	if roles != nil {
+		t.Fatalf("ERROR: expected nil for missing claim, got %v", roles)
+	}
+}
+
+// TestExtractRoles_WrongShape ensures a path that resolves to something
+// other than a list of strings fails closed instead of panicking.
+func TestExtractRoles_WrongShape(t *testing.T) {
+	roles := extractRoles(sampleClaims(), "preferred_username")
+	if roles != nil {
+		t.Fatalf("ERROR: expected nil for non-list claim, got %v", roles)
+	}
+
+	roles = extractRoles(sampleClaims(), "realm_access")
+	if roles != nil {
+		t.Fatalf("ERROR: expected nil when path resolves to an object, got %v", roles)
+	}
+}
+
+// TestResolveRoleClaim_Default is the backward-compat contract: an
+// unconfigured roleclaim must resolve to realm_access.roles, matching the
+// pre-existing hardcoded behavior for every deployment that doesn't set the
+// new option.
+func TestResolveRoleClaim_Default(t *testing.T) {
+	got := resolveRoleClaim("")
+	if got != "realm_access.roles" {
+		t.Fatalf("ERROR: expected default %q, got %q", "realm_access.roles", got)
+	}
+}
+
+// TestResolveRoleClaim_Configured ensures an explicitly configured roleclaim
+// is used as-is, not overridden by the default.
+func TestResolveRoleClaim_Configured(t *testing.T) {
+	got := resolveRoleClaim("resource_access.tornjak-backend.roles")
+	if got != "resource_access.tornjak-backend.roles" {
+		t.Fatalf("ERROR: expected configured value to be preserved, got %q", got)
+	}
+}


### PR DESCRIPTION
Fixes #434

## Root cause

`pkg/agent/authentication/authenticator/keycloak.go` hardcoded role extraction to `realm_access.roles` via a typed `KeycloakClaim`/`RealmAccessSubclaim` struct bound with JSON tags (`AuthenticateRequest`, using `jwt.ParseWithClaims`). There was no way to configure a different claim path, so any deployment where roles live somewhere else in the token - most commonly `resource_access.<clientId>.roles`, Keycloak's own default location for client-scoped roles - couldn't authenticate those roles at all.

## Fix

- Added an optional `roleclaim` HCL config field (dot-separated path), defaulting to `realm_access.roles` when unset, so no existing deployment's config needs to change.
- `AuthenticateRequest` now parses into generic `jwt.MapClaims` instead of the fixed struct; a new `extractRoles` helper walks the configured path. Fails closed (no roles, not a crash) if the path doesn't resolve or resolves to something other than a string list.
- Updated `docs/plugins/plugin_server_authentication_keycloak.md` and `docs/conf/agent/full.conf` to document the new option.

Related prior work: `generalize_auth` (a branch pushed but never opened as a PR, last touched 2024-05-02) attempted a similar dot-path approach. This PR takes the same direction but makes `roleclaim` optional - the branch made it required, which would have broken every existing deployment on upgrade - and adds test coverage the branch didn't have.

## How this was verified

- Reproduced the gap against a real, locally-run Keycloak + Tornjak stack: pulled a real access token, confirmed it carries roles under both `realm_access.roles` and `resource_access.account.roles`, and confirmed the pre-fix code only ever saw the first.
- Added unit tests in `keycloak_test.go`: default path still extracts roles exactly as before (regression case), an arbitrary nested path extracts correctly, a flat single-segment path works, and fail-closed behavior for a missing/wrong-shaped claim.
- Re-ran the same live-Keycloak repro against the fixed code: default config unchanged (control), `roleclaim = "resource_access.account.roles"` now correctly surfaces the previously-invisible roles.
- `go build ./...`, `go test ./...`, `golangci-lint run --timeout 7m` (v2.1.6, matching CI) all pass.