### PR TITLE
Collapse redundant plugin-configuration error wrapping

### DIFF
--- a/api/agent/config.go
+++ b/api/agent/config.go
@@ -97,7 +97,7 @@ func NewAgentsDB(dbPlugin *ast.ObjectItem) (agentdb.AgentDB, error) {
 // NewCRDManager returns ...
 func NewCRDManager(crdPlugin *ast.ObjectItem) (spirecrd.CRDManager, error) {
 	_, data, _ := getPluginConfig(crdPlugin)
-	
+
 	// check if data is defined
 	if data == nil {
 		return nil, errors.New("SPIRECRDManager plugin ('config > plugins > SPIRECRDManager > plugin_data') not populated")
@@ -112,7 +112,7 @@ func NewCRDManager(crdPlugin *ast.ObjectItem) (spirecrd.CRDManager, error) {
 
 	crdManager, err := spirecrd.NewSPIRECRDManager(config.Classname)
 	if err != nil {
-		return nil, errors.Errorf("Could not initialize CRD manager: %v", err)
+		return nil, err
 	}
 
 	return crdManager, nil
@@ -143,7 +143,7 @@ func NewAuthenticator(authenticatorPlugin *ast.ObjectItem) (authenticator.Authen
 		// create authenticator TODO make json an option?
 		authenticator, err := authenticator.NewKeycloakAuthenticator(true, config.IssuerURL, config.Audience)
 		if err != nil {
-			return nil, errors.Errorf("Couldn't configure Authenticator: %v", err)
+			return nil, err
 		}
 		return authenticator, nil
 	default:
@@ -194,7 +194,7 @@ func NewAuthorizer(authorizerPlugin *ast.ObjectItem) (authorization.Authorizer, 
 
 		authorizer, err := authorization.NewRBACAuthorizer(config.Name, roleList, apiV1Mapping)
 		if err != nil {
-			return nil, errors.Errorf("Couldn't configure Authorizer: %v", err)
+			return nil, err
 		}
 		return authorizer, nil
 	default:
@@ -271,9 +271,6 @@ func (s *Server) Configure() error {
 				return fmt.Errorf("plugin DataStore expected to have two keys (type then name)")
 			}
 			s.Db, err = NewAgentsDB(pluginObject)
-			if err != nil {
-				return errors.Errorf("Cannot configure datastore plugin: %v", err)
-			}
 		// configure controller maanger CRD management
 		case "SPIRECRDManager":
 			if len(pluginObject.Keys) != 1 {
@@ -281,27 +278,21 @@ func (s *Server) Configure() error {
 			}
 
 			s.CRDManager, err = NewCRDManager(pluginObject)
-			if err != nil {
-				return errors.Errorf("Cannot configure CRD management plugin: %v", err)
-			}
 		// configure Authenticator
 		case "Authenticator":
 			if len(pluginObject.Keys) != 2 {
 				return fmt.Errorf("plugin Authenticator expected to have two keys (type then name)")
 			}
 			s.Authenticator, err = NewAuthenticator(pluginObject)
-			if err != nil {
-				return errors.Errorf("Cannot configure Authenticator plugin: %v", err)
-			}
 		// configure Authorizer
 		case "Authorizer":
 			if len(pluginObject.Keys) != 2 {
 				return fmt.Errorf("plugin Authorizer expected to have two keys (type then name)")
 			}
 			s.Authorizer, err = NewAuthorizer(pluginObject)
-			if err != nil {
-				return errors.Errorf("Cannot configure Authorizer plugin: %v", err)
-			}
+		}
+		if err != nil {
+			return fmt.Errorf("failed to configure %s plugin: %w", pluginType, err)
 		}
 		// TODO Handle when multiple plugins configured
 	}

--- a/api/agent/config_test.go
+++ b/api/agent/config_test.go
@@ -1,0 +1,189 @@
+package api
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl"
+)
+
+// parseTestConfig decodes a Tornjak HCL config string the same way
+// cmd/agent/main.go's parseTornjakConfig does, so tests exercise the same
+// Plugins (*ast.Node) shape Configure() sees in production.
+func parseTestConfig(t *testing.T, hclStr string) *TornjakConfig {
+	t.Helper()
+	c := &TornjakConfig{}
+	if err := hcl.Decode(c, hclStr); err != nil {
+		t.Fatalf("ERROR: failed to decode test HCL config: %v", err)
+	}
+	return c
+}
+
+// TestConfigure_DataStoreFailure ensures a DataStore failure surfaces as a
+// single "failed to configure DataStore plugin" wrap around the
+// constructor's own specific error (driver/filename), with no second
+// generic wrap duplicating it.
+func TestConfigure_DataStoreFailure(t *testing.T) {
+	config := parseTestConfig(t, `
+server {
+  spire_socket_path = "unix:///tmp/spire-server/private/api.sock"
+}
+plugins {
+  DataStore "sql" {
+    plugin_data {
+      drivername = "sqlite3"
+      filename = "/nonexistent-dir-xyz/db.sqlite3"
+    }
+  }
+}
+`)
+	s := &Server{TornjakConfig: config}
+	err := s.Configure()
+	if err == nil {
+		t.Fatal("ERROR: expected Configure to fail for an unwritable DB path, got nil error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "failed to configure DataStore plugin:") {
+		t.Fatalf("ERROR: expected shared wrap %q in message, got %q", "failed to configure DataStore plugin:", msg)
+	}
+	if !strings.Contains(msg, "no such file or directory") {
+		t.Fatalf("ERROR: expected constructor's specific detail preserved in message, got %q", msg)
+	}
+	if strings.Contains(msg, "Cannot configure datastore plugin") {
+		t.Fatalf("ERROR: old redundant wrap text should no longer appear, got %q", msg)
+	}
+}
+
+// TestConfigure_AuthenticatorFailure ensures an Authenticator failure (here,
+// OIDC discovery against an unreachable issuer) surfaces as a single shared
+// wrap around keycloak.go's own error, without the old
+// "Couldn't configure Authenticator" duplicate layer in between.
+func TestConfigure_AuthenticatorFailure(t *testing.T) {
+	config := parseTestConfig(t, `
+server {
+  spire_socket_path = "unix:///tmp/spire-server/private/api.sock"
+}
+plugins {
+  Authenticator "Keycloak" {
+    plugin_data {
+      issuer = "http://127.0.0.1:1/realms/test"
+      audience = "tornjak-backend"
+    }
+  }
+}
+`)
+	s := &Server{TornjakConfig: config}
+	err := s.Configure()
+	if err == nil {
+		t.Fatal("ERROR: expected Configure to fail for an unreachable OIDC issuer, got nil error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "failed to configure Authenticator plugin:") {
+		t.Fatalf("ERROR: expected shared wrap %q in message, got %q", "failed to configure Authenticator plugin:", msg)
+	}
+	if !strings.Contains(msg, "Could not set up OIDC Discovery client with issuer") {
+		t.Fatalf("ERROR: expected keycloak.go's specific detail preserved in message, got %q", msg)
+	}
+	if strings.Contains(msg, "Couldn't configure Authenticator:") {
+		t.Fatalf("ERROR: old redundant wrap text should no longer appear, got %q", msg)
+	}
+}
+
+// TestConfigure_AuthorizerFailure ensures an Authorizer failure (an
+// allowed_roles entry referencing a role that was never defined) surfaces
+// as a single shared wrap, without the old "Couldn't configure Authorizer"
+// duplicate layer.
+func TestConfigure_AuthorizerFailure(t *testing.T) {
+	config := parseTestConfig(t, `
+server {
+  spire_socket_path = "unix:///tmp/spire-server/private/api.sock"
+}
+plugins {
+  Authorizer "RBAC" {
+    plugin_data {
+      name = "Test Policy"
+      role "admin" { desc = "admin person" }
+      APIv1 "GET /api/v1/spire/serverinfo" { allowed_roles = ["nonexistent"] }
+    }
+  }
+}
+`)
+	s := &Server{TornjakConfig: config}
+	err := s.Configure()
+	if err == nil {
+		t.Fatal("ERROR: expected Configure to fail for an undefined allowed_roles entry, got nil error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "failed to configure Authorizer plugin:") {
+		t.Fatalf("ERROR: expected shared wrap %q in message, got %q", "failed to configure Authorizer plugin:", msg)
+	}
+	if !strings.Contains(msg, "lists undefined role") {
+		t.Fatalf("ERROR: expected rbac.go's specific detail preserved in message, got %q", msg)
+	}
+	if strings.Contains(msg, "Couldn't configure Authorizer:") {
+		t.Fatalf("ERROR: old redundant wrap text should no longer appear, got %q", msg)
+	}
+}
+
+// TestConfigure_CRDManagerFailure ensures a SPIRECRDManager failure (real
+// in-cluster config lookup failing because the test isn't running inside a
+// Kubernetes pod) surfaces as a single shared wrap, without the old
+// "Could not initialize CRD manager" duplicate layer.
+func TestConfigure_CRDManagerFailure(t *testing.T) {
+	config := parseTestConfig(t, `
+server {
+  spire_socket_path = "unix:///tmp/spire-server/private/api.sock"
+}
+plugins {
+  SPIRECRDManager {
+    plugin_data {
+      classname = "spire-mgmt-spire"
+    }
+  }
+}
+`)
+	s := &Server{TornjakConfig: config}
+	err := s.Configure()
+	if err == nil {
+		t.Fatal("ERROR: expected Configure to fail outside a Kubernetes cluster, got nil error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "failed to configure SPIRECRDManager plugin:") {
+		t.Fatalf("ERROR: expected shared wrap %q in message, got %q", "failed to configure SPIRECRDManager plugin:", msg)
+	}
+	if !strings.Contains(msg, "in-cluster config") {
+		t.Fatalf("ERROR: expected manager.go's specific detail preserved in message, got %q", msg)
+	}
+	if strings.Contains(msg, "Could not initialize CRD manager:") {
+		t.Fatalf("ERROR: old redundant wrap text should no longer appear, got %q", msg)
+	}
+}
+
+// TestConfigure_Success is the control case: a valid DataStore-only config
+// (no Authenticator/Authorizer, which default to no-ops) must still
+// configure successfully against a real, writable sqlite file, proving the
+// refactor of Configure()'s plugin loop didn't touch the golden path.
+func TestConfigure_Success(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "tornjak-config-test.sqlite3")
+	config := parseTestConfig(t, `
+server {
+  spire_socket_path = "unix:///tmp/spire-server/private/api.sock"
+}
+plugins {
+  DataStore "sql" {
+    plugin_data {
+      drivername = "sqlite3"
+      filename = "`+dbPath+`"
+    }
+  }
+}
+`)
+	s := &Server{TornjakConfig: config}
+	if err := s.Configure(); err != nil {
+		t.Fatalf("ERROR: expected Configure to succeed for a valid config, got %v", err)
+	}
+	if s.Db == nil {
+		t.Fatal("ERROR: expected s.Db to be set after a successful DataStore configuration")
+	}
+}


### PR DESCRIPTION
Fixes (partially) #395

Configure()'s plugin loop wraps every plugin constructor's error a second time, right on top of a wrap the constructor already added. NewAuthenticator, NewAuthorizer, and NewCRDManager each return a generic "couldn't configure X" style error, and then the loop wraps that again with "cannot configure X plugin." Neither message adds anything new, it's just noise, and it's exactly what the issue is describing (`Cannot configure auth plugin: Couldn't configure Auth:`).

This isn't just an Authenticator/Keycloak thing either. NewAgentsDB, NewCRDManager, and NewAuthorizer all have this same double-wrap shape. NewAgentsDB is the one exception, since its wrap actually has real info in it (driver name, file path), so I left that one alone.

I reproduced this against a real unreachable OIDC issuer, nothing listening on the port, running the actual CLI:

```
before:
Cannot Configure: Cannot configure Authenticator plugin: Couldn't configure Authenticator: Could not set up OIDC Discovery client with issuer = '...': error fetching ...: dial tcp ...: connect: connection refused

after:
Cannot Configure: failed to configure Authenticator plugin: Could not set up OIDC Discovery client with issuer = '...': error fetching ...: dial tcp ...: connect: connection refused
```

The fix: the loop's four separate wraps collapse into one shared check after the switch, reusing the plugin type it already extracted, using %w so it stays wrappable (same style as the invalid plugin type key check a few lines up). Then I dropped the three generic constructor wraps in NewAuthenticator, NewAuthorizer, and NewCRDManager since that framing now comes from the loop instead.

Worth calling out, #398 (adding the issuer URL to the discovery error) is untouched, you can see it's still there in the reproduction above.

Verification: go build, go vet (only pre-existing findings, all in files I didn't touch), gofmt clean, and go test ./api/... ./pkg/... all passing.

Added tests in api/agent/config_test.go, one real failure per plugin type plus a success case: a bad sqlite path, an unreachable OIDC issuer, an RBAC config pointing at a role that doesn't exist, and a CRD manager failing because we're not actually in a k8s cluster. Plus one control test that a normal config still configures fine. Each failure test checks that the new wrap shows up, the constructor's actual detail survives, and the old redundant text is gone.

This covers the nesting/redundancy part of the issue. It doesn't touch the "maybe suggest a fix" idea from the thread, happy to open that separately if it's wanted.