### PR TITLE
Retry OIDC discovery with backoff instead of crashing on first failure

### DIFF
--- a/pkg/agent/authentication/authenticator/keycloak.go
+++ b/pkg/agent/authentication/authenticator/keycloak.go
@@ -9,12 +9,20 @@ import (
 	"time"
 
 	keyfunc "github.com/MicahParks/keyfunc/v2"
+	backoff "github.com/cenkalti/backoff/v4"
 	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/pardot/oidc/discovery"
 	"github.com/pkg/errors"
 
 	"github.com/spiffe/tornjak/pkg/agent/authentication/user"
 )
+
+// oidcDiscoveryMaxElapsedTime bounds how long NewKeycloakAuthenticator will
+// keep retrying OIDC discovery before giving up. Long enough to ride out a
+// Keycloak container that's still starting (a common race in docker-compose
+// and Kubernetes, where startup order isn't guaranteed), short enough that a
+// genuinely misconfigured issuer still fails fast.
+const oidcDiscoveryMaxElapsedTime = 30 * time.Second
 
 type RealmAccessSubclaim struct {
 	Roles []string `json:"roles"`
@@ -60,8 +68,23 @@ func getJWKeyFunc(httpjwks bool, jwksInfo string) (*keyfunc.JWKS, error) {
 //
 //	get keyfunc based on https
 func NewKeycloakAuthenticator(httpjwks bool, issuerURL string, audience string) (*KeycloakAuthenticator, error) {
-	// perform OIDC discovery
-	oidcClient, err := discovery.NewClient(context.Background(), issuerURL)
+	expBackoff := backoff.NewExponentialBackOff()
+	expBackoff.MaxElapsedTime = oidcDiscoveryMaxElapsedTime
+	return newKeycloakAuthenticator(httpjwks, issuerURL, audience, expBackoff)
+}
+
+// newKeycloakAuthenticator takes an explicit backoff.BackOff so tests can
+// exercise the retry behavior without waiting out the real
+// oidcDiscoveryMaxElapsedTime window.
+func newKeycloakAuthenticator(httpjwks bool, issuerURL string, audience string, oidcBackoff backoff.BackOff) (*KeycloakAuthenticator, error) {
+	// perform OIDC discovery, retrying with backoff since the IAM server may
+	// still be starting up
+	var oidcClient *discovery.Client
+	err := backoff.Retry(func() error {
+		var discoverErr error
+		oidcClient, discoverErr = discovery.NewClient(context.Background(), issuerURL)
+		return discoverErr
+	}, oidcBackoff)
 	if err != nil {
 		return nil, errors.Errorf("Could not set up OIDC Discovery client with issuer = '%s': %v", issuerURL, err)
 	}

--- a/pkg/agent/authentication/authenticator/keycloak_test.go
+++ b/pkg/agent/authentication/authenticator/keycloak_test.go
@@ -1,0 +1,147 @@
+package authenticator
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	backoff "github.com/cenkalti/backoff/v4"
+)
+
+// testBackoff returns a fast exponential backoff so tests exercise real
+// retry behavior without waiting out the production oidcDiscoveryMaxElapsedTime
+// window (30s).
+func testBackoff(maxElapsed time.Duration) backoff.BackOff {
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = 20 * time.Millisecond
+	b.MaxInterval = 100 * time.Millisecond
+	b.MaxElapsedTime = maxElapsed
+	return b
+}
+
+// freePort reserves a TCP port and immediately releases it, leaving nothing
+// listening. Connections to it fail with a real "connection refused" until
+// something else binds to it, which is exactly the condition we want to
+// simulate an IAM server that isn't up yet.
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("ERROR: failed to reserve a port: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	if err := ln.Close(); err != nil {
+		t.Fatalf("ERROR: failed to release reserved port: %v", err)
+	}
+	return port
+}
+
+// discoveryHandler serves the minimum OIDC discovery document and JWKS
+// pardot/oidc/discovery.Client and keyfunc.Get need to succeed.
+func discoveryHandler(baseURL string) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"issuer": %q, "jwks_uri": %q}`, baseURL, baseURL+"/certs")
+	})
+	mux.HandleFunc("/certs", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"keys": []}`)
+	})
+	return mux
+}
+
+// TestNewKeycloakAuthenticator_SucceedsImmediately is the control case: a
+// reachable issuer from the first attempt must still succeed exactly like
+// before this change, proving the retry wrapper didn't disturb the golden
+// path.
+func TestNewKeycloakAuthenticator_SucceedsImmediately(t *testing.T) {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		discoveryHandler(server.URL).ServeHTTP(w, r)
+	}))
+	defer server.Close()
+
+	auth, err := newKeycloakAuthenticator(true, server.URL, "tornjak-backend", testBackoff(5*time.Second))
+	if err != nil {
+		t.Fatalf("ERROR: expected immediate success against a reachable issuer, got %v", err)
+	}
+	if auth.audience != "tornjak-backend" {
+		t.Fatalf("ERROR: expected audience %q, got %q", "tornjak-backend", auth.audience)
+	}
+	if auth.jwksURL != server.URL+"/certs" {
+		t.Fatalf("ERROR: expected jwksURL %q, got %q", server.URL+"/certs", auth.jwksURL)
+	}
+}
+
+// TestNewKeycloakAuthenticator_RecoversFromTransientOIDCFailure reproduces
+// the actual scenario behind #410: the IAM server isn't reachable yet when
+// Tornjak starts, then comes up a moment later. Before this change, the
+// first failed discovery attempt would have been fatal; now it must retry
+// and succeed once the issuer becomes reachable.
+func TestNewKeycloakAuthenticator_RecoversFromTransientOIDCFailure(t *testing.T) {
+	port := freePort(t)
+	issuerURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	type result struct {
+		auth *KeycloakAuthenticator
+		err  error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		auth, err := newKeycloakAuthenticator(true, issuerURL, "tornjak-backend", testBackoff(5*time.Second))
+		resultCh <- result{auth, err}
+	}()
+
+	// give it a couple of real failed attempts against the refused port
+	// before the issuer becomes reachable
+	time.Sleep(150 * time.Millisecond)
+
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		t.Fatalf("ERROR: failed to bind the now-available issuer on port %d: %v", port, err)
+	}
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		discoveryHandler(issuerURL).ServeHTTP(w, r)
+	}))
+	server.Listener = ln
+	server.Start()
+	defer server.Close()
+
+	select {
+	case res := <-resultCh:
+		if res.err != nil {
+			t.Fatalf("ERROR: expected recovery once the issuer became reachable, got %v", res.err)
+		}
+		if res.auth.jwksURL != issuerURL+"/certs" {
+			t.Fatalf("ERROR: expected jwksURL %q, got %q", issuerURL+"/certs", res.auth.jwksURL)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ERROR: newKeycloakAuthenticator did not recover within the backoff window")
+	}
+}
+
+// TestNewKeycloakAuthenticator_GivesUpAfterMaxElapsedTime ensures a
+// permanently unreachable issuer still fails, and does so within roughly
+// the configured backoff window rather than hanging indefinitely.
+func TestNewKeycloakAuthenticator_GivesUpAfterMaxElapsedTime(t *testing.T) {
+	port := freePort(t) // nothing ever listens on this port
+
+	maxElapsed := 300 * time.Millisecond
+	start := time.Now()
+	_, err := newKeycloakAuthenticator(true, fmt.Sprintf("http://127.0.0.1:%d", port), "tornjak-backend", testBackoff(maxElapsed))
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("ERROR: expected an error for a permanently unreachable issuer, got nil")
+	}
+	if !strings.Contains(err.Error(), "connect: connection refused") && !strings.Contains(err.Error(), "connection refused") {
+		t.Fatalf("ERROR: expected a connection-refused error, got %v", err)
+	}
+	// generous upper bound: should give up close to maxElapsed, not hang
+	if elapsed > 3*time.Second {
+		t.Fatalf("ERROR: expected to give up within a few seconds of maxElapsedTime (%v), took %v", maxElapsed, elapsed)
+	}
+}


### PR DESCRIPTION
Fixes #410

NewKeycloakAuthenticator made exactly one attempt to reach Keycloak for OIDC discovery at startup. If Keycloak wasn't reachable yet, that error went straight to log.Fatal and killed the process. This is a real problem in docker-compose and Kubernetes, where container start order isn't guaranteed, so Keycloak is very often not ready the instant Tornjak boots.

I reproduced this against a real Keycloak container rather than just reading the code: starting Tornjak before Keycloak was up crashed it immediately, matching the log the reporter posted in the issue thread.

I also checked the other half of what the issue title implies, whether Tornjak crashes once it's already running and Keycloak later goes down. It doesn't, and I confirmed that two ways. First, the request path (verificationMiddleware -> AuthenticateRequest) never calls out to Keycloak per request, it only reads an in-memory JWKS cache built once at startup. I killed Keycloak while Tornjak was actively serving requests and it kept responding fine the whole time. Second, the only other thing that talks to Keycloak after startup is the background JWKS refresh goroutine, so I built the same keyfunc client Tornjak's code builds, pointed it at a real Keycloak, killed Keycloak, and forced a refresh. The failure just goes to RefreshErrorHandler, which logs it, and the process keeps running, matching what the keyfunc library itself documents. So the actual gap really is only at startup, this PR is scoped to that.

The fix wraps the discovery call in exponential backoff (github.com/cenkalti/backoff/v4, same library already used for the DataStore plugin's setup in api/agent/config.go, so nothing new gets pulled in), capped at 30 seconds. A Keycloak that's still starting gets ridden out instead of killing the process on the first try. A genuinely unreachable issuer still fails loud after the window, same as before, just not instantly, which matches what a maintainer described wanting in the issue thread back in 2024 ("try a couple times and ultimately crash if it can't, to alert administrators").

I did consider a more thorough fix: have Tornjak start serving immediately with a not-ready authenticator and initialize the real one in a background goroutine with retry, so the server's own liveness isn't coupled to Keycloak's at all, closer to how a Kubernetes readiness probe should behave. I think that's a genuinely better long-term design, but it's a bigger change to startup sequencing than what was asked for here and I'd rather get a small, targeted fix in front of you first. Happy to explore that separately if there's interest.

Verification: go build, go vet (clean on the changed package), gofmt clean, go test ./api/... ./pkg/... all passing, plus five runs of the new tests back to back to check for flakiness around the port-timing in the transient-recovery test.

Added pkg/agent/authentication/authenticator/keycloak_test.go:
- TestNewKeycloakAuthenticator_SucceedsImmediately, the control case, a reachable issuer still succeeds on the first try exactly like before
- TestNewKeycloakAuthenticator_RecoversFromTransientOIDCFailure, starts against a refused port, then binds a real HTTP server to that same port mid-retry and confirms it recovers
- TestNewKeycloakAuthenticator_GivesUpAfterMaxElapsedTime, confirms a permanently unreachable issuer still errors out within roughly the configured window instead of hanging

To keep the tests fast and deterministic without waiting out the real 30 second window, I split NewKeycloakAuthenticator into a thin public wrapper and an internal newKeycloakAuthenticator that takes an explicit backoff.BackOff, so tests can pass a much shorter one. Production behavior is unchanged, this is just a test seam.